### PR TITLE
Only compute the norm against unmasked tokens

### DIFF
--- a/helios/nn/flexihelios.py
+++ b/helios/nn/flexihelios.py
@@ -694,6 +694,9 @@ class Encoder(FlexiHeliosBase):
                 other=exited_tokens.detach(),
             )
 
+        # we apply the norm before we add the removed tokens,
+        # so that the norm is only computed against "real" tokens
+        tokens = self.norm(tokens)
         # we don't care about the mask returned by add_removed_tokens, since we will
         # just use the original, unclipped mask here
         tokens, _ = self.add_removed_tokens(tokens, indices, new_mask)
@@ -743,7 +746,7 @@ class Encoder(FlexiHeliosBase):
             masked_modality_name = patchified_tokens_and_masks.get_masked_modality_name(
                 modality
             )
-            output_dict[modality] = self.norm(x_modality)
+            output_dict[modality] = x_modality
             output_dict[masked_modality_name] = getattr(
                 patchified_tokens_and_masks, masked_modality_name
             )


### PR DESCRIPTION
This was a small mistake I noticed in the Galileo codebase. Its too late to fix it there (and the model still does okay with it) but we can avoid making that same mistake here.

Currently, the norm stats will be computed against both real tokens and the "inserted" tokens (which are just noise). This PR updates it so that the norm stats are only computed against the real tokens. 