### PR TITLE
MAE loss updates

### DIFF
--- a/helios/train/loss.py
+++ b/helios/train/loss.py
@@ -426,19 +426,24 @@ class L2Loss(Loss):
         return F.mse_loss(pred, target)
 
 
-@LOSS_REGISTRY.register("imagel2")
-class ImageL2Loss(Loss):
-    """Loss function for L2 (mean squared error) over images."""
+@LOSS_REGISTRY.register("mae")
+class MAELoss(Loss):
+    """Loss function masked auto-encoding (reconstruction)."""
 
-    name = "ImageL2"
+    name = "MAE"
 
-    def __init__(self, only_decode: bool = True):
-        """Initialize all patch discrimination loss.
+    def __init__(
+        self, loss_function: str = "MSELoss", only_decode: bool = False, **kwargs: Any
+    ):
+        """Initialize MAE loss.
 
         Args:
+            loss_function: pytorch loss to use
             only_decode: only calculate loss on DECODER masked tokens, otherwise all
+            **kwargs: arguments for pytorch loss constructor
         """
         self.only_decode = only_decode
+        self.loss = getattr(torch.nn, loss_function)(reduction="sum", **kwargs)
 
     # data: [B, H, W, T, C]
     def _flatten_helios_data(self, data: TokensAndMasks) -> tuple[Tensor, Tensor]:
@@ -466,7 +471,7 @@ class ImageL2Loss(Loss):
     def compute(
         self, predictions: TokensAndMasks, targets: TokensAndMasks, **kwargs: Any
     ) -> Tensor:
-        """Compute L2 loss between predictions and targets.
+        """Compute MAE loss between predictions and targets.
 
         Args:
             predictions: Model predictions.
@@ -491,7 +496,7 @@ class ImageL2Loss(Loss):
             decode = label_masks != MaskValue.MISSING.value
         data = data * decode
         labels = labels * decode
-        return F.mse_loss(data, labels, reduction="sum") / torch.count_nonzero(decode)
+        return self.loss(data, labels) / torch.count_nonzero(decode)
 
 
 @LOSS_REGISTRY.register("cross_entropy")

--- a/helios/train/train_module/mae.py
+++ b/helios/train/train_module/mae.py
@@ -41,7 +41,7 @@ class MAETrainModuleConfig(HeliosTrainModuleConfig):
     """
 
     loss_config: LossConfig = field(
-        default_factory=lambda: LossConfig(loss_config={"type": "l1"})
+        default_factory=lambda: LossConfig(loss_config={"type": "mae"})
     )
     masking_config: MaskingConfig = field(
         default_factory=lambda: MaskingConfig(strategy_config={"type": "random"})

--- a/scripts/base_debug_scripts/mae.py
+++ b/scripts/base_debug_scripts/mae.py
@@ -101,8 +101,8 @@ def build_train_module_config(
     """Build the train module config for an experiment."""
     LR = 0.002
     RANK_MICROBATCH_SIZE = 32
-    ENCODE_RATIO = 0.4
-    DECODE_RATIO = 0.6
+    ENCODE_RATIO = 0.1
+    DECODE_RATIO = 0.9
     WD = 0.02
     optim_config = AdamWConfig(lr=LR, weight_decay=WD)
     masking_config = MaskingConfig(
@@ -114,7 +114,7 @@ def build_train_module_config(
     )
     loss_config = LossConfig(
         loss_config={
-            "type": "imagel2",  # TODO: Should be registered via enum names
+            "type": "mae",
         }
     )
     token_exit_cfg = {modality: 4 for modality in common.supported_modality_names}

--- a/tests/integration/nn/test_mae.py
+++ b/tests/integration/nn/test_mae.py
@@ -8,7 +8,7 @@ import torch
 from helios.data.constants import Modality, ModalitySpec
 from helios.nn.flexihelios import Encoder, Predictor, Reconstructor, TokensAndMasks
 from helios.nn.mae import MAE
-from helios.train.loss import ImageL2Loss
+from helios.train.loss import MAELoss
 from helios.train.masking import MaskedHeliosSample, MaskValue
 
 logger = logging.getLogger(__name__)
@@ -138,7 +138,7 @@ def test_mae_with_loss(
     assert (output.sentinel2_l2a_mask == x.sentinel2_l2a_mask).all()
 
     # this reflects the forward_model function in mae
-    loss_fn = ImageL2Loss()
+    loss_fn = MAELoss()
     reconstructed = output
     labels = x.as_dict()
     labels.pop("timestamps")


### PR DESCRIPTION
- Allows configurable MAE Loss over images (l1, l2, smoothl1, etc.)
- Switching between loss based only on DECODER tokens or all non-MISSING tokens
- Better defaults for MAE base debug script

Example:
`python3 scripts/base_debug_scripts/mae.py launch mae_smoothl1 ai2/saturn-cirrascale --run_name=mae_smoothl1 --train_module.loss_config.loss_config.loss_function=SmoothL1Loss --train_module.loss_config.loss_config.beta=0.1`