### PR TITLE
Update requirements.txt to have compatibility with other libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ai2-olmo-core @ git+https://github.com/allenai/olmo-core.git@8919dff
 beaker-py>=1.32.0
 cartopy
 class-registry
-einops==0.7.0
+einops>=0.7.0
 gcsfs
 geobench
 GitPython>=3.0,<4.0


### PR DESCRIPTION
Rather than pinning einops it seems to be fine to use newer versions and this way we can install helios with other libraries like rslearn without conflict.