### PR TITLE
Throttling reads

### DIFF
--- a/helios/data/dataset.py
+++ b/helios/data/dataset.py
@@ -362,7 +362,7 @@ class HeliosDataset(Dataset):
         normalize: bool = True,
         use_samples_with_missing_supported_modalities: bool = False,
         cache_dir: UPath | None = None,
-        samples_per_sec: int | None = None,
+        samples_per_sec: float | None = None,
     ):
         """Initialize the dataset.
 
@@ -779,7 +779,7 @@ class HeliosDatasetConfig(Config):
     normalize: bool = True
     use_samples_with_missing_supported_modalities: bool = False
     cache_dir: str | None = None
-    samples_per_sec: int | None = None
+    samples_per_sec: float | None = None
 
     def validate(self) -> None:
         """Validate the configuration and build kwargs.


### PR DESCRIPTION
This adds read throttling in the HeliosDataset. I put it in the HeliosDataset so it was easy to make it apply to reading from h5py_dir (on WEKA) only, and not when reading from cache_dir.

With 43 MB H5 files, setting `samples_per_sec=2/NUM_DATA_LOADER_WORKERS` with 8 GPUs seems to result in 1 GB/sec read performance. (When I calculate it, (2*8)*43 MB = 688 MB; I'm not sure why it is about 2x of that.) It scales by both number of GPUs and number of data loader workers (since the latter is per-GPU).

Throttling is mainly useful in combination with `cache_dir` (local disk caching of the H5 files). This way, it applies only during the first epoch, and later epochs are faster. Without `cache_dir`, it just means we are artificially slowing down reading compared to what the GPU handles, which seems weird; other approaches like sharding the H5 files may be better.