### PR TITLE
Add memory cleanup for in-loop evals

### DIFF
--- a/helios/internal/common.py
+++ b/helios/internal/common.py
@@ -92,7 +92,7 @@ def build_launch_config(
         workspace=workspace,
         clusters=clusters,
         weka_buckets=weka_buckets,
-        beaker_image=f"petew/{OLMoCoreBeakerImage.stable_cu126}",  # we can all use the same image for now trying petes to see if it works or we need a copy in our workspace
+        beaker_image=f"petew/{OLMoCoreBeakerImage.stable_cu128}",  # we can all use the same image for now trying petes to see if it works or we need a copy in our workspace
         num_nodes=1,
         num_gpus=1,
         shared_memory="256GiB",


### PR DESCRIPTION
Some investigation into slow evaluations, especially PASTIS.

1. The main difference between PASTIS and other evaluations is the number of timesteps (12 vs. 1), which makes loading samples and computing embeddings slower. With 12 times more tokens, self-attention also takes longer to compute. Below is a comparison between Sen1Floods11 and PASTIS:

```
[2025-04-29 10:36:20] INFO     [helios.evals.embeddings:46, rank=0] Time to get item: 0.0112 seconds
[2025-04-29 10:36:20] INFO     [helios.evals.embeddings:56, rank=0] Time to run embedding: 0.0500 seconds
[2025-04-29 10:36:20] INFO     [helios.evals.embeddings:66, rank=0] Time to pool and append embeddings: 0.0509 seconds
```

```
[2025-04-29 10:45:11] INFO     [helios.evals.embeddings:46, rank=0] Time to get item: 0.0155 seconds
[2025-04-29 10:45:11] INFO     [helios.evals.embeddings:56, rank=0] Time to run embedding: 0.2569 seconds
[2025-04-29 10:45:11] INFO     [helios.evals.embeddings:66, rank=0] Time to pool and append embeddings: 0.0010 seconds
```

PASTIS took `5x` time to get embeddings for each batch, at the same time, we use a small `batch_size` for PASTIS because the input sample is much larger than Sen1Floods11. We set `batch_size` to 8 for PASTIS and 128 for Sen1Floods11. So PASTIS will need to run more rounds of get embeddings than Sen1Floods11. 

Some upcoming evaluations like Breizcrop and SICKLE have a similar issue, and we need to set a larger epoch to avoid long evaluation times.

Here's the evaluation time on a L40S.

```
Finished m-eurosat evaluations in 237.7 seconds.
Finished breizhcrops evaluations in 1598.4 seconds.
Finished mados evaluations in 138.8 seconds.
Finished sen1floods11 evaluations in 262.2 seconds.
Finished pastis evaluations in 576.7 seconds.
Finished pastis-r evaluations in 769.0 seconds.
```

2. I added memory cleanup after each evaluation to make sure we run release GPU and CPU memory immediately after each evaluation. Here's a run on Jupyter: https://beaker.allen.ai/orgs/ai2/workspaces/earth-systems/work/01JT16FNBQYKPKCYNM5P1Y0NPP?taskId=01JT16FNCAP6BAK0D8YG96JE32&jobId=01JT16FNFVR5X1YBK1RS3VNPR9. I ran eval every step and didn't observe significant changes in eval time. 

```
Step 1

Finished m-eurosat evaluations in 154.6 seconds.
Finished mados evaluations in 113.1 seconds.
Finished sen1floods11 evaluations in 135.8 seconds.
Finished pastis evaluations in 800.0 seconds.
Finished pastis-r evaluations in 1253.8 seconds.

Step 2

Finished m-eurosat evaluations in 151.3 seconds.
Finished mados evaluations in 91.7 seconds.
Finished sen1floods11 evaluations in 112.9 seconds.
Finished pastis evaluations in 820.1 seconds.
Finished pastis-r evaluations in 1247.8 seconds.
```

I added a TODO to move the slow evaluations outside training loop, and launch jobs separately (potentially apply DataParallel to speed it up). 




