### PR TITLE
Fix so2sat

### DIFF
--- a/helios/evals/datasets/geobench_dataset.py
+++ b/helios/evals/datasets/geobench_dataset.py
@@ -1,5 +1,6 @@
 """GeoBench datasets, returning data in the Helios format."""
 
+import logging
 import os
 from pathlib import Path
 from types import MethodType
@@ -23,6 +24,7 @@ from .normalize import impute_normalization_stats, normalize_bands
 
 torch.multiprocessing.set_sharing_strategy("file_system")
 
+logger = logging.getLogger(__name__)
 
 GEOBENCH_DIR = UPath("/weka/dfive-default/presto-geobench/dataset/geobench")
 
@@ -53,7 +55,6 @@ class GeobenchDataset(Dataset):
             norm_method: Normalization method to use, only when norm_stats_from_pretrained is False
             visualize_samples: Whether to visualize samples
         """
-        self.dataset_name = dataset
         config = DATASET_TO_CONFIG[dataset]
         self.config = config
         self.num_classes = config.num_classes
@@ -84,9 +85,7 @@ class GeobenchDataset(Dataset):
 
         # hack: https://github.com/ServiceNow/geo-bench/issues/22
         task.get_dataset_dir = MethodType(
-            lambda self: geobench_dir
-            / f"{config.task_type.value}_v1.0"
-            / self.dataset_name,
+            lambda self: geobench_dir / f"{config.task_type.value}_v1.0" / dataset,
             task,
         )
 
@@ -104,6 +103,11 @@ class GeobenchDataset(Dataset):
         self.active_indices = range(int(len(self.dataset)))
         self.norm_method = norm_method
         self.visualize_samples = visualize_samples
+
+        self.multiply_by_10_000 = False
+        if dataset == "m-so2sat":
+            logging.info(f"self.multiply_by_10_000 set to True for {dataset}")
+            self.multiply_by_10_000 = True
 
     @staticmethod
     def _get_norm_stats(
@@ -161,7 +165,7 @@ class GeobenchDataset(Dataset):
         assert (
             x.shape[-1] == 13
         ), f"All datasets must have 13 channels, not {x.shape[-1]}"
-        if self.dataset_name == "m-so2sat":
+        if self.multiply_by_10_000:
             x = x * 10_000
 
         # Normalize using the downstream task's normalization stats


### PR DESCRIPTION
We were getting very poor results on the so2sat dataset. This should fix it. 

From the so2sat [readme](https://github.com/zhu-xlab/So2Sat-LCZ42):
> The pixel values are devided by 10,000 to decimal reflectance.

We undo this so that it reflects the scaling adopted by our pretraining datasets (and other eval datasets). 