### PR TITLE
Pin olmo-core to the latest version with relaxed numpy requirements (until the next package release)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ai2-olmo-core==2.1.0
+ai2-olmo-core @ git+https://github.com/allenai/OLMo-core.git@ebe0b1981b81576ce7a87362501dc84c6d9adb3f # Pin here until >2.1.0 is released.
 albumentations
 beaker-py==1.34.1
 breizhcrops


### PR DESCRIPTION
Context: https://allenai.slack.com/archives/C08AU86NMCM/p1753909648155789?thread_ts=1752878875.550339&cid=C08AU86NMCM