### PR TITLE
Mock batch speed ups

### DIFF
--- a/helios/data/dataloader.py
+++ b/helios/data/dataloader.py
@@ -298,7 +298,7 @@ class HeliosDataLoader(DataLoaderBase):
 
     def _get_mock_sample(self, rng: np.random.Generator) -> HeliosSample:
         output_dict = {}
-        standard_hw = 128
+        standard_hw = 64
         if Modality.SENTINEL2_L2A.name in self.dataset.training_modalities:
             mock_sentinel2_l2a = rng.random(
                 (standard_hw, standard_hw, 12, 12), dtype=np.float32


### PR DESCRIPTION
Mock batches were slow on startup recently, this makes them way faster. Also, represents the size of our data better.

Time taken to collate mock batch: 0.41863298416137695 seconds with 64 
Time taken to collate mock batch: 2.856456756591797 seconds with 128 

Time taken to collate mock batch: 27.89523458480835 seconds with 256