### PR TITLE
Remove duplicate beaker-py requirement.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dataset_creation = { file = ["requirements_dataset_creation.txt"] }
 dev = { file = ["requirements-dev.txt"] }
 eval = { file = ["requirements-eval.txt"] }
 beaker = { file = ["requirements-beaker.txt"] }
-all = { file = ["requirements.txt", "requirements-dev.txt", "requirements-eval.txt"] }
+all = { file = ["requirements.txt", "requirements-dev.txt", "requirements-eval.txt", "requirements-beaker.txt"] }
 
 [tool.setuptools.package-data]
 "helios.data.norm_configs" = ["*.json"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ai2-olmo-core @ git+https://github.com/allenai/OLMo-core.git@abc12e50ba756c21e575452cfc6f150dafa9509e # Pin here until >2.1.0 is released.
 albumentations
-beaker-py==1.34.1
 breizhcrops==0.0.4.1 # Force the latest available
 cartopy
 class-registry


### PR DESCRIPTION
It was in both requirements.txt and requirements-beaker.txt, now it should only appear in requirements-beaker.txt. This makes it possible to install helios (most of which does not depend on Beaker) while using different beaker-py version.

It is easier to relax in Helios than in rslearn_projects since Beaker is less tightly woven as a dependency in different parts compared to rslearn_projects.