### PR TITLE
remove breiz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ai2-olmo-core @ git+https://github.com/allenai/OLMo-core.git@abc12e50ba756c21e575452cfc6f150dafa9509e # Pin here until >2.1.0 is released.
 albumentations
-breizhcrops==0.0.4.1 # Force the latest available
 cartopy
 class-registry
 einops>=0.7.0


### PR DESCRIPTION
Breizhcrops is only used in eval and imports a ton of unneded stuff like jupyter notebook, ipython etc and is already in the eval reqs but got left here