### PR TITLE
Add inference quickstart guide

### DIFF
--- a/docs/inference_quickstart.md
+++ b/docs/inference_quickstart.md
@@ -19,28 +19,8 @@ Now we can use the `olmoearth_pretrain` library to initialize the model in pytor
 Below, we initialize the OlmoEarth-v1-Base model.
 
 ```python
-# TBD, I'm assuming we will have model IDs or something like that to easily initialize
-# the model.
-import json
-from pathlib import Path
-
-import torch
-
-from olmo_core.config import Config
-from olmo_core.distributed.checkpoint import load_model_and_optim_state
-
-checkpoint_path = Path("/weka/dfive-default/helios/checkpoints/joer/phase2.0_base_lr0.0001_wd0.02/step667200")
-with (checkpoint_path / "config.json").open() as f:
-    config_dict = json.load(f)
-    model_config = Config.from_dict(config_dict["model"])
-
-model = model_config.build()
-
-train_module_dir = checkpoint_path / "model_and_optim"
-load_model_and_optim_state(str(train_module_dir), model)
-
-device = torch.device("cuda")
-model.to(device)
+from olmoearth_pretrain.model_loader import ModelID, load_model
+model = load_model(ModelID.OLMOEARTH_V1_BASE)
 ```
 
 ## Obtain Satellite Imagery
@@ -141,7 +121,11 @@ Now we can apply the model on the image. We recommend applying it on inputs betw
 generally perform better, but require more GPU time.
 
 ```python
+import torch
 from olmoearth_pretrain.train.masking import MaskedOlmoEarthSample, MaskValue
+
+device = torch.device("cuda")
+model.to(device)
 
 # Run the model on the topleft 64x64 of the image.
 sample = MaskedOlmoEarthSample(


### PR DESCRIPTION
This covers how to initialize the model, get a satellite image, and compute embeddings on it.

This is intended to be lightweight but we can have a more detailed one in rslearn that uses rslearn to get an image time series to apply OlmoEarth on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a concise quickstart guide showing how to initialize OlmoEarth, fetch a Sentinel-2 image, and compute embeddings with example code.
> 
> - **Docs**:
>   - Add `docs/inference_quickstart.md` quickstart guide for running inference with OlmoEarth.
>     - Environment setup (Python 3.12 with `uv`) and model initialization via `load_model(ModelID.OLMOEARTH_V1_BASE)`.
>     - Sentinel-2 L2A data acquisition via Copernicus Browser or direct `wget` link; unzip instructions.
>     - Preprocessing with `rasterio`/`WarpedVRT` to read bands at 10m, stack, and reshape; normalization with `Normalizer(Strategy.COMPUTED)`.
>     - Inference example creating `MaskedOlmoEarthSample`, running `model.encoder(...)`, and pooling features to obtain embeddings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 237b8b539d8a729e6b469e9b02763590dc3ccf79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->