### PR TITLE
Add convenience function to load models from Hugging Face.

### DIFF
--- a/olmoearth_pretrain/model_loader.py
+++ b/olmoearth_pretrain/model_loader.py
@@ -51,9 +51,8 @@ def load_model(model_id: ModelID, load_weights: bool = True) -> torch.nn.Module:
     """
     # We ignore bandit warnings here since we are just downloading config and weights,
     # not any code.
-    config_fname = hf_hub_download(
-        repo_id="allenai/olmoearth_pretrain", filename=f"{model_id.value}-config.json"
-    )  # nosec
+    repo_id = f"allenai/{model_id.value}"
+    config_fname = hf_hub_download(repo_id=repo_id, filename="config.json")  # nosec
     with open(config_fname) as f:
         config_dict = json.load(f)
         model_config = Config.from_dict(config_dict["model"])
@@ -63,9 +62,7 @@ def load_model(model_id: ModelID, load_weights: bool = True) -> torch.nn.Module:
     if not load_weights:
         return model
 
-    pth_fname = hf_hub_download(
-        repo_id="allenai/olmoearth_pretrain", filename=f"{model_id.value}.pth"
-    )  # nosec
-    state_dict = torch.load(pth_fname)
+    pth_fname = hf_hub_download(repo_id=repo_id, filename="weights.pth")  # nosec
+    state_dict = torch.load(pth_fname, map_location="cpu")
     model.load_state_dict(state_dict)
     return model


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a utility to build OlmoEarth models from Hugging Face config and optionally load weights.
> 
> - **Python / Pretrain**:
>   - **New module** `olmoearth_pretrain/model_loader.py`:
>     - Introduces `ModelID` enum with `OLMOEARTH_V1_NANO`, `OLMOEARTH_V1_TINY`, `OLMOEARTH_V1_BASE`.
>     - Adds `load_model(model_id, load_weights=True)` to download `config.json`, build the model via `Config.from_dict(...).build()`, and optionally fetch `weights.pth` and `load_state_dict` from Hugging Face.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d53cbc3d2620f83dd20a9779f1553876e2ca3425. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->