### PR TITLE
Add pypi package publish workflow.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,19 +11,12 @@ concurrency:
 jobs:
   build-dist:
     name: Build distribution
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "0.9.5"
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
 
       - name: Verify version matches tag
         run: |
@@ -35,11 +28,7 @@ jobs:
           fi
           echo "Version check passed: $TAG_VERSION"
 
-      - name: Install build dependencies
-        run: uv pip install --system build
-
-      - name: Build package
-        run: python -m build
+      - run: uv build
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -58,7 +47,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a release-triggered GitHub Actions workflow that builds with uv, validates tag/version, and publishes the built dist to PyPI.
> 
> - **CI/CD**:
>   - **New workflow**: `/.github/workflows/publish.yml`
>     - Trigger: `release` (type `released`) with concurrency control.
>     - **Build distribution**: checkout, setup `uv`, verify tag matches `pyproject.toml` version, run `uv build`, upload `dist/` artifact.
>     - **Publish to PyPI**: download `dist/` artifact, publish via `pypa/gh-action-pypi-publish` using OIDC; environment set to `pypi` with URL `https://pypi.org/p/olmoearth_pretrain`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 339dc09293dadfb0b46d36da034facd949f0d554. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->