### PR TITLE
Remove unused kwargs argument for stricter type checking

### DIFF
--- a/olmoearth_pretrain/data/dataloader.py
+++ b/olmoearth_pretrain/data/dataloader.py
@@ -180,11 +180,8 @@ class OlmoEarthDataLoader(DataLoaderBase):
                     )
         barrier()
 
-    def reshuffle(
-        self, epoch: int | None = None, in_memory: bool = False, **kwargs: Any
-    ) -> None:
+    def reshuffle(self, epoch: int | None = None, in_memory: bool = False) -> None:
         """Reshuffle the data."""
-        del kwargs
         if epoch is None:
             epoch = 1 if self._epoch is None else self._epoch + 1  # type: ignore
         if epoch <= 0:


### PR DESCRIPTION
The reshuffle function in`dataloader.py` currently takes in a kwargs argument, which it immediately deletes. This means that mypy would fail to detect a misspelling of a function arg like: `reshuffle(epoc = 1)`.  Currently no additional kwargs are passed to the function throughout the codebase, so provided this change passes mypy it should be fully safe. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unused `**kwargs` from `OlmoEarthDataLoader.reshuffle` and its no-op deletion for cleaner API and stricter typing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a42aa3bce08daa76c920ecbf4004d2814764d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->