### PR TITLE
Fix broken images on PyPI by using absolute URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="assets/OlmoEarth-logo.png" alt="OlmoEarth Logo" style="width: 600px; margin-left:'auto' margin-right:'auto' display:'block'"/>
+  <img src="https://raw.githubusercontent.com/allenai/olmoearth_pretrain/main/assets/OlmoEarth-logo.png" alt="OlmoEarth Logo" style="width: 600px; margin-left:'auto' margin-right:'auto' display:'block'"/>
   <br>
   <br>
 </div>
@@ -38,7 +38,7 @@ OlmoEarth is built using [OLMo-core](https://github.com/allenai/OLMo-core.git). 
 
 ## Model Summary
 
-<img src="assets/model.png" alt="Model Architecture Diagram" style="width: 800px; margin-left:'auto' margin-right:'auto' display:'block'"/>
+<img src="https://raw.githubusercontent.com/allenai/olmoearth_pretrain/main/assets/model.png" alt="Model Architecture Diagram" style="width: 800px; margin-left:'auto' margin-right:'auto' display:'block'"/>
 
 The OlmoEarth models are trained on three satellite modalities (Sentinel 2, Sentinel 1 and Landsat) and six derived maps (OpenStreetMap, WorldCover, USDA Cropland Data Layer, SRTM DEM, WRI Canopy Height Map, and WorldCereal).
 | Model Size | Weights | Encoder Params | Decoder Params |
@@ -67,7 +67,7 @@ Our pretraining dataset contains 285,288 samples from around the world of 2.56km
 
 The distribution of the samples is available below:
 
-<img src="assets/datamap.png" alt="Training sample distribution" style="width: 500px; margin-left:'auto' margin-right:'auto' display:'block'"/>
+<img src="https://raw.githubusercontent.com/allenai/olmoearth_pretrain/main/assets/datamap.png" alt="Training sample distribution" style="width: 500px; margin-left:'auto' margin-right:'auto' display:'block'"/>
 
 The dataset can be downloaded [here](https://huggingface.co/datasets/allenai/olmoearth_pretrain_dataset).
 


### PR DESCRIPTION
   Update all image references in README.md to use absolute GitHub URLs
   instead of relative paths. This ensures images render correctly on
   both GitHub and PyPI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace relative image paths in README with absolute GitHub raw URLs for proper rendering across platforms.
> 
> - **Docs (`README.md`)**:
>   - Update image sources to absolute GitHub raw URLs for:
>     - `assets/OlmoEarth-logo.png`
>     - `assets/model.png`
>     - `assets/datamap.png`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd7b1cfa5ad0ae2e8c3974221befc6c958797bde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->