### PR TITLE
fix: Apply ruff linting fixes - remove unused imports and fix formatting

### DIFF
--- a/scripts/archived/2025_04_09_multidataset/train.py
+++ b/scripts/archived/2025_04_09_multidataset/train.py
@@ -2,24 +2,6 @@
 
 import logging
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -38,6 +20,23 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_04_10_modality_masking/train.py
+++ b/scripts/archived/2025_04_10_modality_masking/train.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.data.normalize import Strategy
@@ -35,6 +18,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_10_modality_masking/train_base.py
+++ b/scripts/archived/2025_04_10_modality_masking/train_base.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.data.normalize import Strategy
@@ -35,6 +18,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_10_modality_masking/train_multidataset.py
+++ b/scripts/archived/2025_04_10_modality_masking/train_multidataset.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -36,6 +19,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_10_modality_masking/train_multidataset_base.py
+++ b/scripts/archived/2025_04_10_modality_masking/train_multidataset_base.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -36,6 +19,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_10_modality_masking/train_multidataset_base_decodeless.py
+++ b/scripts/archived/2025_04_10_modality_masking/train_multidataset_base_decodeless.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -36,6 +19,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_10_modality_masking/train_multidataset_base_newmasking.py
+++ b/scripts/archived/2025_04_10_modality_masking/train_multidataset_base_newmasking.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -36,6 +19,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_10_modality_masking/train_multidataset_newmasking.py
+++ b/scripts/archived/2025_04_10_modality_masking/train_multidataset_newmasking.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -36,6 +19,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_10_modality_masking/train_orig.py
+++ b/scripts/archived/2025_04_10_modality_masking/train_orig.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.data.normalize import Strategy
@@ -35,6 +18,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_10_modality_masking/train_orig_base.py
+++ b/scripts/archived/2025_04_10_modality_masking/train_orig_base.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.data.normalize import Strategy
@@ -35,6 +18,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_15_random_range/shared.py
+++ b/scripts/archived/2025_04_15_random_range/shared.py
@@ -2,6 +2,21 @@
 
 import logging
 
+from helios.data.concat import HeliosConcatDatasetConfig
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.data.dataset import HeliosDatasetConfig
+from helios.internal.experiment import CommonComponents, HeliosVisualizeConfig
+from helios.nn.flexihelios import EncoderConfig, PoolingType, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
+from helios.train.loss import LossConfig
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import Config, DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -18,22 +33,6 @@ from olmo_core.train.checkpoint import CheckpointerConfig
 from olmo_core.train.common import Duration, LoadStrategy
 from olmo_core.train.config import TrainerConfig
 from upath import UPath
-
-from helios.data.concat import HeliosConcatDatasetConfig
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.data.dataset import HeliosDatasetConfig
-from helios.internal.experiment import CommonComponents, HeliosVisualizeConfig
-from helios.nn.flexihelios import EncoderConfig, PoolingType, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
-from helios.train.loss import LossConfig
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_15_random_range/train_modality1.py
+++ b/scripts/archived/2025_04_15_random_range/train_modality1.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_15_random_range/train_old.py
+++ b/scripts/archived/2025_04_15_random_range/train_old.py
@@ -1,5 +1,7 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/2025_04_15_random_range/train_randspace1.py
+++ b/scripts/archived/2025_04_15_random_range/train_randspace1.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_15_random_range/train_randspace2.py
+++ b/scripts/archived/2025_04_15_random_range/train_randspace2.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_15_random_range/train_range1.py
+++ b/scripts/archived/2025_04_15_random_range/train_range1.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_15_random_range/train_range2.py
+++ b/scripts/archived/2025_04_15_random_range/train_range2.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_15_random_range/train_range3.py
+++ b/scripts/archived/2025_04_15_random_range/train_range3.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_15_random_range/train_range4.py
+++ b/scripts/archived/2025_04_15_random_range/train_range4.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_15_random_range/train_range5.py
+++ b/scripts/archived/2025_04_15_random_range/train_range5.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_15_random_range/train_range6.py
+++ b/scripts/archived/2025_04_15_random_range/train_range6.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_15_random_range/train_range7.py
+++ b/scripts/archived/2025_04_15_random_range/train_range7.py
@@ -1,5 +1,9 @@
 """Launch script."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_18_galileo_contrastive/galileo_base.py
+++ b/scripts/archived/2025_04_18_galileo_contrastive/galileo_base.py
@@ -6,23 +6,6 @@ These Settings are meant to help you get quick results on a single GPU in minima
 import logging
 from typing import Any
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -41,6 +24,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_22_st_model/shared.py
+++ b/scripts/archived/2025_04_22_st_model/shared.py
@@ -1,22 +1,5 @@
 """Trying to prototype fitting everything into olmo core."""
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -34,6 +17,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 MIN_PATCH_SIZE = 1
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_04_22_st_model/train.py
+++ b/scripts/archived/2025_04_22_st_model/train.py
@@ -1,5 +1,7 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/2025_04_22_st_model/train_augusta.py
+++ b/scripts/archived/2025_04_22_st_model/train_augusta.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -36,6 +19,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_04_22_st_model/train_baseline.py
+++ b/scripts/archived/2025_04_22_st_model/train_baseline.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.flexihelios import EncoderConfig, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,11 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.flexihelios import EncoderConfig, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_baseline_osmonly.py
+++ b/scripts/archived/2025_04_22_st_model/train_baseline_osmonly.py
@@ -1,5 +1,11 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.concat import HeliosConcatDatasetConfig
+from helios.data.dataset import HeliosDatasetConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.flexihelios import EncoderConfig, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
 from olmo_core.config import DType
 from shared import (
     MAX_PATCH_SIZE,
@@ -9,13 +15,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.concat import HeliosConcatDatasetConfig
-from helios.data.dataset import HeliosDatasetConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.flexihelios import EncoderConfig, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_baseline_randspace.py
+++ b/scripts/archived/2025_04_22_st_model/train_baseline_randspace.py
@@ -1,5 +1,11 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.flexihelios import EncoderConfig, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -14,13 +20,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.flexihelios import EncoderConfig, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_budget3000_randspace.py
+++ b/scripts/archived/2025_04_22_st_model/train_budget3000_randspace.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -15,12 +20,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_04_22_st_model/train_budget6000.py
+++ b/scripts/archived/2025_04_22_st_model/train_budget6000.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -10,10 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_04_22_st_model/train_budget6000_randspace.py
+++ b/scripts/archived/2025_04_22_st_model/train_budget6000_randspace.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -15,12 +20,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_04_22_st_model/train_budget6000hwp20.py
+++ b/scripts/archived/2025_04_22_st_model/train_budget6000hwp20.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -10,10 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_04_22_st_model/train_budget6000hwp20_randspace.py
+++ b/scripts/archived/2025_04_22_st_model/train_budget6000hwp20_randspace.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -15,12 +20,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_04_22_st_model/train_decdepth10.py
+++ b/scripts/archived/2025_04_22_st_model/train_decdepth10.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,11 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_decdepth12size384.py
+++ b/scripts/archived/2025_04_22_st_model/train_decdepth12size384.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,11 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_decdepth4.py
+++ b/scripts/archived/2025_04_22_st_model/train_decdepth4.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,11 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_decdepth6.py
+++ b/scripts/archived/2025_04_22_st_model/train_decdepth6.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,11 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_decdepth8.py
+++ b/scripts/archived/2025_04_22_st_model/train_decdepth8.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,11 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_decdepth8size384.py
+++ b/scripts/archived/2025_04_22_st_model/train_decdepth8size384.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,11 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_encdepth24.py
+++ b/scripts/archived/2025_04_22_st_model/train_encdepth24.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     NUM_DATA_LOADER_WORKERS,
     build_dataset_config,
@@ -7,12 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 MIN_PATCH_SIZE = 1
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_04_22_st_model/train_encdepth24_budget3000.py
+++ b/scripts/archived/2025_04_22_st_model/train_encdepth24_budget3000.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     NUM_DATA_LOADER_WORKERS,
     build_dataset_config,
@@ -7,12 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 MIN_PATCH_SIZE = 1
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_04_22_st_model/train_encdepth24_budget6000.py
+++ b/scripts/archived/2025_04_22_st_model/train_encdepth24_budget6000.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     NUM_DATA_LOADER_WORKERS,
     build_dataset_config,
@@ -7,12 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 MIN_PATCH_SIZE = 1
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_04_22_st_model/train_large.py
+++ b/scripts/archived/2025_04_22_st_model/train_large.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,12 +14,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_04_22_st_model/train_osmonly.py
+++ b/scripts/archived/2025_04_22_st_model/train_osmonly.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.concat import HeliosConcatDatasetConfig
+from helios.data.dataset import HeliosDatasetConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
 from olmo_core.config import DType
 from shared import (
     build_dataloader_config,
@@ -8,11 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.concat import HeliosConcatDatasetConfig
-from helios.data.dataset import HeliosDatasetConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
 
 
 def build_dataset_config(common: CommonComponents) -> HeliosDatasetConfig:

--- a/scripts/archived/2025_04_22_st_model/train_osmonly_fsdp.py
+++ b/scripts/archived/2025_04_22_st_model/train_osmonly_fsdp.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.concat import HeliosConcatDatasetConfig
+from helios.data.dataset import HeliosDatasetConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -12,12 +17,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.concat import HeliosConcatDatasetConfig
-from helios.data.dataset import HeliosDatasetConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_dataset_config(common: CommonComponents) -> HeliosDatasetConfig:

--- a/scripts/archived/2025_04_22_st_model/train_ps4.py
+++ b/scripts/archived/2025_04_22_st_model/train_ps4.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     NUM_DATA_LOADER_WORKERS,
     build_dataset_config,
@@ -7,12 +12,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 MIN_PATCH_SIZE = 4
 MAX_PATCH_SIZE = 4

--- a/scripts/archived/2025_04_22_st_model/train_randspace.py
+++ b/scripts/archived/2025_04_22_st_model/train_randspace.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -13,11 +17,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_train_module_config(

--- a/scripts/archived/2025_04_23_benchmarking_ladder/base_galileo_max.py
+++ b/scripts/archived/2025_04_23_benchmarking_ladder/base_galileo_max.py
@@ -3,24 +3,6 @@
 import logging
 from typing import Any
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -39,6 +21,23 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_05_02_randomness/galileo_random_base.py
+++ b/scripts/archived/2025_05_02_randomness/galileo_random_base.py
@@ -3,24 +3,6 @@
 import logging
 from typing import Any
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -39,6 +21,23 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_05_02_st_model/galileo.py
+++ b/scripts/archived/2025_05_02_st_model/galileo.py
@@ -12,7 +12,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.internal.experiment import main
 
 if __name__ == "__main__":

--- a/scripts/archived/2025_05_02_st_model/galileo_budget6000.py
+++ b/scripts/archived/2025_05_02_st_model/galileo_budget6000.py
@@ -12,7 +12,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.internal.experiment import CommonComponents, main
 from helios.train.train_module.galileo import GalileoTrainModuleConfig

--- a/scripts/archived/2025_05_02_st_model/galileo_budget6000hwp20.py
+++ b/scripts/archived/2025_05_02_st_model/galileo_budget6000hwp20.py
@@ -12,7 +12,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.internal.experiment import CommonComponents, main
 from helios.train.train_module.galileo import GalileoTrainModuleConfig

--- a/scripts/archived/2025_05_02_st_model/galileo_budget9000hwp20.py
+++ b/scripts/archived/2025_05_02_st_model/galileo_budget9000hwp20.py
@@ -12,7 +12,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.internal.experiment import CommonComponents, main
 from helios.train.train_module.galileo import GalileoTrainModuleConfig

--- a/scripts/archived/2025_05_02_st_model/galileo_decoder8.py
+++ b/scripts/archived/2025_05_02_st_model/galileo_decoder8.py
@@ -12,7 +12,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.internal.experiment import CommonComponents, main
 from helios.nn.galileo import GalileoConfig
 

--- a/scripts/archived/2025_05_02_st_model/galileo_shared.py
+++ b/scripts/archived/2025_05_02_st_model/galileo_shared.py
@@ -6,23 +6,6 @@ These Settings are meant to help you get quick results on a single GPU in minima
 import logging
 from typing import Any
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -42,6 +25,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_05_02_st_model/shared.py
+++ b/scripts/archived/2025_05_02_st_model/shared.py
@@ -1,22 +1,5 @@
 """Trying to prototype fitting everything into olmo core."""
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -34,6 +17,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 MIN_PATCH_SIZE = 1
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_05_02_st_model/train.py
+++ b/scripts/archived/2025_05_02_st_model/train.py
@@ -1,5 +1,7 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/2025_05_02_st_model/train_baseline.py
+++ b/scripts/archived/2025_05_02_st_model/train_baseline.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.flexihelios import EncoderConfig, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,11 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.flexihelios import EncoderConfig, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_02_st_model/train_budget12000hwp20.py
+++ b/scripts/archived/2025_05_02_st_model/train_budget12000hwp20.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -10,11 +14,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_05_02_st_model/train_budget3000.py
+++ b/scripts/archived/2025_05_02_st_model/train_budget3000.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -10,10 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_05_02_st_model/train_budget4500.py
+++ b/scripts/archived/2025_05_02_st_model/train_budget4500.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -10,10 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_05_02_st_model/train_budget6000.py
+++ b/scripts/archived/2025_05_02_st_model/train_budget6000.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -10,10 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_05_02_st_model/train_budget6000hwp20.py
+++ b/scripts/archived/2025_05_02_st_model/train_budget6000hwp20.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -10,10 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_05_02_st_model/train_budget9000hwp20.py
+++ b/scripts/archived/2025_05_02_st_model/train_budget9000hwp20.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -10,11 +14,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_05_02_st_model/train_large.py
+++ b/scripts/archived/2025_05_02_st_model/train_large.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,12 +14,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_02_st_model/train_large_budget3000.py
+++ b/scripts/archived/2025_05_02_st_model/train_large_budget3000.py
@@ -1,5 +1,11 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,13 +15,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_02_st_model/train_large_budget6000.py
+++ b/scripts/archived/2025_05_02_st_model/train_large_budget6000.py
@@ -1,5 +1,11 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.nn.st_model import STEncoderConfig, STPredictorConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,13 +15,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.nn.st_model import STEncoderConfig, STPredictorConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_02_st_model/train_ps2.py
+++ b/scripts/archived/2025_05_02_st_model/train_ps2.py
@@ -1,5 +1,14 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.flexihelios import PoolingType
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from olmo_core.train.callbacks import (
     ConfigSaverCallback,
     GarbageCollectorCallback,
@@ -15,16 +24,6 @@ from shared import (
     build_train_module_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.flexihelios import PoolingType
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 
 
 def build_trainer_config(common: CommonComponents) -> TrainerConfig:

--- a/scripts/archived/2025_05_05_bigdata/galileo.py
+++ b/scripts/archived/2025_05_05_bigdata/galileo.py
@@ -12,7 +12,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.internal.experiment import main
 
 if __name__ == "__main__":

--- a/scripts/archived/2025_05_05_bigdata/galileo_baseline.py
+++ b/scripts/archived/2025_05_05_bigdata/galileo_baseline.py
@@ -11,7 +11,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.internal.experiment import CommonComponents, main
 from helios.internal.utils import MODEL_SIZE_ARGS
 from helios.nn.flexihelios import EncoderConfig, PredictorConfig

--- a/scripts/archived/2025_05_05_bigdata/galileo_baseline2.py
+++ b/scripts/archived/2025_05_05_bigdata/galileo_baseline2.py
@@ -11,7 +11,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.internal.experiment import CommonComponents, main
 from helios.internal.utils import MODEL_SIZE_ARGS
 from helios.nn.flexihelios import EncoderConfig, PredictorConfig

--- a/scripts/archived/2025_05_05_bigdata/galileo_baseline2_osm.py
+++ b/scripts/archived/2025_05_05_bigdata/galileo_baseline2_osm.py
@@ -10,14 +10,13 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-from olmo_core.config import Config, DType
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.internal.experiment import CommonComponents, main
 from helios.internal.utils import MODEL_SIZE_ARGS
 from helios.nn.flexihelios import EncoderConfig, PredictorConfig
 from helios.nn.galileo import GalileoConfig
+from olmo_core.config import Config, DType
 
 MIN_PATCH_SIZE = 1
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_05_05_bigdata/galileo_baseline2_osm_osmbig.py
+++ b/scripts/archived/2025_05_05_bigdata/galileo_baseline2_osm_osmbig.py
@@ -10,14 +10,13 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-from olmo_core.config import Config, DType
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.internal.experiment import CommonComponents, main
 from helios.internal.utils import MODEL_SIZE_ARGS
 from helios.nn.flexihelios import EncoderConfig, PredictorConfig
 from helios.nn.galileo import GalileoConfig
+from olmo_core.config import Config, DType
 
 MIN_PATCH_SIZE = 1
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_05_05_bigdata/galileo_baseline2_presto_osm.py
+++ b/scripts/archived/2025_05_05_bigdata/galileo_baseline2_presto_osm.py
@@ -10,14 +10,13 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-from olmo_core.config import Config, DType
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.internal.experiment import CommonComponents, main
 from helios.internal.utils import MODEL_SIZE_ARGS
 from helios.nn.flexihelios import EncoderConfig, PredictorConfig
 from helios.nn.galileo import GalileoConfig
+from olmo_core.config import Config, DType
 
 MIN_PATCH_SIZE = 1
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_05_05_bigdata/galileo_baseline_large.py
+++ b/scripts/archived/2025_05_05_bigdata/galileo_baseline_large.py
@@ -11,7 +11,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.internal.experiment import CommonComponents, main
 from helios.internal.utils import MODEL_SIZE_ARGS
 from helios.nn.flexihelios import EncoderConfig, PredictorConfig

--- a/scripts/archived/2025_05_05_bigdata/galileo_large.py
+++ b/scripts/archived/2025_05_05_bigdata/galileo_large.py
@@ -12,7 +12,6 @@ from galileo_shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
 from helios.internal.experiment import CommonComponents, main
 from helios.nn.galileo import GalileoConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig

--- a/scripts/archived/2025_05_05_bigdata/galileo_shared.py
+++ b/scripts/archived/2025_05_05_bigdata/galileo_shared.py
@@ -6,23 +6,6 @@ These Settings are meant to help you get quick results on a single GPU in minima
 import logging
 from typing import Any
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -42,6 +25,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_05_05_bigdata/shared.py
+++ b/scripts/archived/2025_05_05_bigdata/shared.py
@@ -1,22 +1,5 @@
 """Trying to prototype fitting everything into olmo core."""
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -34,6 +17,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 MIN_PATCH_SIZE = 1
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/2025_05_05_bigdata/train.py
+++ b/scripts/archived/2025_05_05_bigdata/train.py
@@ -1,5 +1,7 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/2025_05_05_bigdata/train_baseline.py
+++ b/scripts/archived/2025_05_05_bigdata/train_baseline.py
@@ -1,5 +1,9 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.flexihelios import EncoderConfig, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,11 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.flexihelios import EncoderConfig, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_05_bigdata/train_baseline_large.py
+++ b/scripts/archived/2025_05_05_bigdata/train_baseline_large.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.flexihelios import EncoderConfig, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     MAX_PATCH_SIZE,
     MIN_PATCH_SIZE,
@@ -9,12 +14,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.flexihelios import EncoderConfig, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_05_bigdata/train_budget6000.py
+++ b/scripts/archived/2025_05_05_bigdata/train_budget6000.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,10 +11,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
 
 
 def my_build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_05_05_bigdata/train_large.py
+++ b/scripts/archived/2025_05_05_bigdata/train_large.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,10 +11,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
 
 
 def my_build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_05_bigdata/train_large_budget6000.py
+++ b/scripts/archived/2025_05_05_bigdata/train_large_budget6000.py
@@ -1,5 +1,10 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,12 +13,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_13_mae/galileo_contrastive.py
+++ b/scripts/archived/2025_05_13_mae/galileo_contrastive.py
@@ -5,23 +5,6 @@ These Settings are meant to help you get quick results on a single GPU in minima
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -42,6 +25,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_05_13_mae/galileo_contrastive_mae.py
+++ b/scripts/archived/2025_05_13_mae/galileo_contrastive_mae.py
@@ -5,23 +5,6 @@ These Settings are meant to help you get quick results on a single GPU in minima
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -43,6 +26,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_05_20_windowed_attention/shared.py
+++ b/scripts/archived/2025_05_20_windowed_attention/shared.py
@@ -1,22 +1,5 @@
 """Trying to prototype fitting everything into olmo core."""
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -39,6 +22,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 MIN_PATCH_SIZE = 4
 MAX_PATCH_SIZE = 4

--- a/scripts/archived/2025_05_20_windowed_attention/train.py
+++ b/scripts/archived/2025_05_20_windowed_attention/train.py
@@ -1,5 +1,6 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -9,8 +10,6 @@ from shared import (
     build_visualize_config,
     my_build_common_components,
 )
-
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/2025_05_20_windowed_attention/train_budget1500.py
+++ b/scripts/archived/2025_05_20_windowed_attention/train_budget1500.py
@@ -1,5 +1,7 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.experiment import CommonComponents, main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -9,9 +11,6 @@ from shared import (
     build_visualize_config,
     my_build_common_components,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.experiment import CommonComponents, main
 
 
 def my_build_dataloader_config(common: CommonComponents) -> HeliosDataLoaderConfig:

--- a/scripts/archived/2025_05_20_windowed_attention/train_ps1to8.py
+++ b/scripts/archived/2025_05_20_windowed_attention/train_ps1to8.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -9,10 +12,6 @@ from shared import (
     build_visualize_config,
     my_build_common_components,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
 
 
 def my_build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_20_windowed_attention/train_ws5.py
+++ b/scripts/archived/2025_05_20_windowed_attention/train_ws5.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -9,10 +12,6 @@ from shared import (
     build_visualize_config,
     my_build_common_components,
 )
-
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 
 def my_build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_05_20_windowed_attention/train_ws5_budget1500.py
+++ b/scripts/archived/2025_05_20_windowed_attention/train_ws5_budget1500.py
@@ -1,5 +1,8 @@
 """Trying to prototype fitting everything into olmo core."""
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.latent_mim import LatentMIMConfig
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -9,10 +12,6 @@ from shared import (
     build_visualize_config,
     my_build_common_components,
 )
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.latent_mim import LatentMIMConfig
 
 
 def my_build_model_config(common: CommonComponents) -> LatentMIMConfig:

--- a/scripts/archived/2025_06_02_modality_investigation/galileo.py
+++ b/scripts/archived/2025_06_02_modality_investigation/galileo.py
@@ -1,5 +1,7 @@
 """Script for v0 sweep for Galileo."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/2025_06_02_modality_investigation/shared.py
+++ b/scripts/archived/2025_06_02_modality_investigation/shared.py
@@ -3,24 +3,6 @@
 import logging
 from collections.abc import Callable
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -50,6 +32,23 @@ from helios.train.train_module.contrastive_latentmim import (
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from helios.train.train_module.train_module import HeliosTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_06_10_cross_masking_investigation/eval.py
+++ b/scripts/archived/2025_06_10_cross_masking_investigation/eval.py
@@ -4,6 +4,20 @@ The eval.sh calls this script with all the different checkpoints we had for this
 model architecture related to fixed modality masking.
 """
 
+from helios.data.constants import Modality
+from helios.internal.experiment import (
+    CommonComponents,
+    main,
+)
+from helios.nn.flexihelios import (
+    PoolingType,
+)
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from latent_mim_128_cross import (
     build_common_components,
     build_dataloader_config,
@@ -22,21 +36,6 @@ from olmo_core.train.callbacks import (
 from olmo_core.train.checkpoint import CheckpointerConfig
 from olmo_core.train.common import Duration, LoadStrategy
 from olmo_core.train.config import TrainerConfig
-
-from helios.data.constants import Modality
-from helios.internal.experiment import (
-    CommonComponents,
-    main,
-)
-from helios.nn.flexihelios import (
-    PoolingType,
-)
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 
 
 def build_trainer_config(common: CommonComponents) -> TrainerConfig:

--- a/scripts/archived/2025_06_10_cross_masking_investigation/galileo_128_cross.py
+++ b/scripts/archived/2025_06_10_cross_masking_investigation/galileo_128_cross.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import WSD
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -43,6 +24,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import WSD
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_06_10_cross_masking_investigation/latent_mim_128_cross.py
+++ b/scripts/archived/2025_06_10_cross_masking_investigation/latent_mim_128_cross.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import WSD
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -43,6 +24,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import WSD
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_06_23_naip/eval.py
+++ b/scripts/archived/2025_06_23_naip/eval.py
@@ -4,6 +4,20 @@ The eval.sh calls this script with all the different checkpoints we had for this
 model architecture related to fixed modality masking.
 """
 
+from helios.data.constants import Modality
+from helios.internal.experiment import (
+    CommonComponents,
+    main,
+)
+from helios.nn.flexihelios import (
+    PoolingType,
+)
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from olmo_core.train.callbacks import (
     BeakerCallback,
     CheckpointerCallback,
@@ -22,21 +36,6 @@ from train import (
     build_visualize_config,
     my_build_common_components,
 )
-
-from helios.data.constants import Modality
-from helios.internal.experiment import (
-    CommonComponents,
-    main,
-)
-from helios.nn.flexihelios import (
-    PoolingType,
-)
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 
 
 def build_trainer_config(common: CommonComponents) -> TrainerConfig:

--- a/scripts/archived/2025_06_23_naip/eval_alldata.py
+++ b/scripts/archived/2025_06_23_naip/eval_alldata.py
@@ -1,19 +1,18 @@
 """Evaluation for models trained on all data."""
 
 from eval import build_trainer_config
+from helios.data.concat import HeliosConcatDatasetConfig
+from helios.data.dataset import HeliosDatasetConfig
+from helios.internal.experiment import (
+    CommonComponents,
+    main,
+)
 from train import (
     build_dataloader_config,
     build_model_config,
     build_train_module_config,
     build_visualize_config,
     my_build_common_components,
-)
-
-from helios.data.concat import HeliosConcatDatasetConfig
-from helios.data.dataset import HeliosDatasetConfig
-from helios.internal.experiment import (
-    CommonComponents,
-    main,
 )
 
 

--- a/scripts/archived/2025_06_23_naip/train.py
+++ b/scripts/archived/2025_06_23_naip/train.py
@@ -7,25 +7,6 @@ It corresponds to this run:
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -53,6 +34,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_06_23_naip/train_alldata.py
+++ b/scripts/archived/2025_06_23_naip/train_alldata.py
@@ -5,20 +5,19 @@ It corresponds to this run:
 - W&B: https://wandb.ai/eai-ai2/v0.2_sweep/runs/ra4x5vlx
 """
 
-from train import (
-    build_dataloader_config,
-    build_model_config,
-    build_train_module_config,
-    build_trainer_config,
-    build_visualize_config,
-)
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.internal.common import build_common_components
 from helios.internal.experiment import (
     CommonComponents,
     main,
+)
+from train import (
+    build_dataloader_config,
+    build_model_config,
+    build_train_module_config,
+    build_trainer_config,
+    build_visualize_config,
 )
 
 

--- a/scripts/archived/2025_06_24_galileo_contrastive_repro/galileo.py
+++ b/scripts/archived/2025_06_24_galileo_contrastive_repro/galileo.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import ConstantWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -44,6 +25,24 @@ from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
 from helios.train.train_module.train_module import HeliosTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import ConstantWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_06_26_dataset_percentage_experiments/eval.py
+++ b/scripts/archived/2025_06_26_dataset_percentage_experiments/eval.py
@@ -4,6 +4,20 @@ The eval.sh calls this script with all the different checkpoints we had for this
 model architecture related to fixed modality masking.
 """
 
+from helios.data.constants import Modality
+from helios.internal.experiment import (
+    CommonComponents,
+    main,
+)
+from helios.nn.flexihelios import (
+    PoolingType,
+)
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from latent_mim_all_data import (
     build_common_components,
     build_dataloader_config,
@@ -22,21 +36,6 @@ from olmo_core.train.callbacks import (
 from olmo_core.train.checkpoint import CheckpointerConfig
 from olmo_core.train.common import Duration, LoadStrategy
 from olmo_core.train.config import TrainerConfig
-
-from helios.data.constants import Modality
-from helios.internal.experiment import (
-    CommonComponents,
-    main,
-)
-from helios.nn.flexihelios import (
-    PoolingType,
-)
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 
 
 def build_trainer_config(common: CommonComponents) -> TrainerConfig:

--- a/scripts/archived/2025_06_26_dataset_percentage_experiments/latent_mim_all_data.py
+++ b/scripts/archived/2025_06_26_dataset_percentage_experiments/latent_mim_all_data.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import WSD
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -43,6 +24,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import WSD
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_07_10_no_map_ssl/train_cross_random.py
+++ b/scripts/archived/2025_07_10_no_map_ssl/train_cross_random.py
@@ -3,25 +3,6 @@
 import logging
 from typing import Any
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import WSD
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -45,6 +26,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import WSD
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_07_21_gse/train.py
+++ b/scripts/archived/2025_07_21_gse/train.py
@@ -7,25 +7,6 @@ It corresponds to this run:
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -53,6 +34,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_07_21_gse/train_cdl.py
+++ b/scripts/archived/2025_07_21_gse/train_cdl.py
@@ -7,25 +7,6 @@ It corresponds to this run:
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -53,6 +34,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_07_21_gse/train_chm.py
+++ b/scripts/archived/2025_07_21_gse/train_chm.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -50,6 +31,24 @@ from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
 )
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_07_21_gse/train_worldpop.py
+++ b/scripts/archived/2025_07_21_gse/train_worldpop.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -48,6 +29,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_07_21_gse/train_worldpop_mae.py
+++ b/scripts/archived/2025_07_21_gse/train_worldpop_mae.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -48,6 +29,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_07_21_gse/train_worldpop_wattn.py
+++ b/scripts/archived/2025_07_21_gse/train_worldpop_wattn.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -47,6 +28,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_07_31_cross_pooled_encoding/train_early_cross_pool.py
+++ b/scripts/archived/2025_07_31_cross_pooled_encoding/train_early_cross_pool.py
@@ -3,25 +3,6 @@
 import logging
 from typing import Any
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import ConstantWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -46,6 +27,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import ConstantWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_07_31_cross_pooled_encoding/train_pooled_encoder.py
+++ b/scripts/archived/2025_07_31_cross_pooled_encoding/train_pooled_encoder.py
@@ -3,25 +3,6 @@
 import logging
 from typing import Any
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import ConstantWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -46,6 +27,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import ConstantWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_08_14_worldcereal/train.py
+++ b/scripts/archived/2025_08_14_worldcereal/train.py
@@ -7,25 +7,6 @@ It corresponds to this run:
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -53,6 +34,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_08_15_modality_patchdisc/latent_mim_modality_patchdisc.py
+++ b/scripts/archived/2025_08_15_modality_patchdisc/latent_mim_modality_patchdisc.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -48,6 +29,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_08_15_modality_patchdisc/latent_mim_modality_patchdisc_add_contrastive.py
+++ b/scripts/archived/2025_08_15_modality_patchdisc/latent_mim_modality_patchdisc_add_contrastive.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -50,6 +31,24 @@ from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
 )
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_08_15_modality_patchdisc/latent_mim_modality_patchdisc_cutmix.py
+++ b/scripts/archived/2025_08_15_modality_patchdisc/latent_mim_modality_patchdisc_cutmix.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -48,6 +29,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_08_26_dataset_percentage/latent_mim_cross_random_contrastive_per-modality.py
+++ b/scripts/archived/2025_08_26_dataset_percentage/latent_mim_cross_random_contrastive_per-modality.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import ConstantWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -50,6 +31,24 @@ from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
 )
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import ConstantWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_08_28_contrastive_cross_pooling/baseline.py
+++ b/scripts/archived/2025_08_28_contrastive_cross_pooling/baseline.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import ConstantWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -50,6 +31,24 @@ from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
 )
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import ConstantWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_08_28_contrastive_cross_pooling/lmim_contrastive_cross_pooling.py
+++ b/scripts/archived/2025_08_28_contrastive_cross_pooling/lmim_contrastive_cross_pooling.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import ConstantWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -52,6 +33,24 @@ from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
 )
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import ConstantWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_09_02_add_register_tokens/lmim_contrastive_per_modality_base.py
+++ b/scripts/archived/2025_09_02_add_register_tokens/lmim_contrastive_per_modality_base.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import ConstantWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -50,6 +31,24 @@ from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
 )
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import ConstantWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_09_10_phase1/script.py
+++ b/scripts/archived/2025_09_10_phase1/script.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import ConstantWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -50,6 +31,24 @@ from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
 )
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import ConstantWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/2025_09_10_phase1/script_chm.py
+++ b/scripts/archived/2025_09_10_phase1/script_chm.py
@@ -2,15 +2,6 @@
 
 import logging
 
-from script import (
-    build_dataloader_config,
-    build_dataset_config,
-    build_model_config,
-    build_train_module_config,
-    build_trainer_config,
-    build_visualize_config,
-)
-
 from helios.data.constants import Modality
 from helios.internal.common import build_common_components
 from helios.internal.experiment import (
@@ -21,6 +12,14 @@ from helios.internal.experiment import (
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
+)
+from script import (
+    build_dataloader_config,
+    build_dataset_config,
+    build_model_config,
+    build_train_module_config,
+    build_trainer_config,
+    build_visualize_config,
 )
 
 logger = logging.getLogger(__name__)

--- a/scripts/archived/2025_09_10_phase1/script_chm_cdl_worldcereal.py
+++ b/scripts/archived/2025_09_10_phase1/script_chm_cdl_worldcereal.py
@@ -2,15 +2,6 @@
 
 import logging
 
-from script import (
-    build_dataloader_config,
-    build_dataset_config,
-    build_model_config,
-    build_train_module_config,
-    build_trainer_config,
-    build_visualize_config,
-)
-
 from helios.data.constants import Modality
 from helios.internal.common import build_common_components
 from helios.internal.experiment import (
@@ -21,6 +12,14 @@ from helios.internal.experiment import (
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
+)
+from script import (
+    build_dataloader_config,
+    build_dataset_config,
+    build_model_config,
+    build_train_module_config,
+    build_trainer_config,
+    build_visualize_config,
 )
 
 logger = logging.getLogger(__name__)

--- a/scripts/archived/amp_investigations/amp_base.py
+++ b/scripts/archived/amp_investigations/amp_base.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.data.normalize import Strategy
@@ -35,6 +18,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/base_debug_scripts/cached_dataset/galileo_cached.py
+++ b/scripts/archived/base_debug_scripts/cached_dataset/galileo_cached.py
@@ -5,23 +5,6 @@ These Settings are meant to help you get quick results on a single GPU in minima
 
 import logging
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -39,6 +22,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/base_debug_scripts/contrastive_latentmim.py
+++ b/scripts/archived/base_debug_scripts/contrastive_latentmim.py
@@ -2,24 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -38,6 +20,23 @@ from helios.train.masking import MaskingConfig
 from helios.train.train_module.contrastive_latentmim import (
     ContrastiveLatentMIMTrainModuleConfig,
 )
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/base_debug_scripts/eval_debug/galileo_eval_debug.py
+++ b/scripts/archived/base_debug_scripts/eval_debug/galileo_eval_debug.py
@@ -5,23 +5,6 @@ These Settings are meant to help you get quick results on a single GPU in minima
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -39,6 +22,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/base_debug_scripts/galileo.py
+++ b/scripts/archived/base_debug_scripts/galileo.py
@@ -5,23 +5,6 @@ These Settings are meant to help you get quick results on a single GPU in minima
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -39,6 +22,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/base_debug_scripts/latent_mim.py
+++ b/scripts/archived/base_debug_scripts/latent_mim.py
@@ -2,6 +2,22 @@
 
 import logging
 
+from helios.data.constants import Modality
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.data.dataset import HeliosDatasetConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, HeliosVisualizeConfig, main
+from helios.nn.flexihelios import EncoderConfig, PoolingType, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
+from helios.train.loss import LossConfig
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -19,23 +35,6 @@ from olmo_core.train.checkpoint import CheckpointerConfig
 from olmo_core.train.common import Duration, LoadStrategy
 from olmo_core.train.config import TrainerConfig
 from upath import UPath
-
-from helios.data.constants import Modality
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.data.dataset import HeliosDatasetConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, HeliosVisualizeConfig, main
-from helios.nn.flexihelios import EncoderConfig, PoolingType, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
-from helios.train.loss import LossConfig
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/base_debug_scripts/mae.py
+++ b/scripts/archived/base_debug_scripts/mae.py
@@ -3,23 +3,6 @@
 import logging
 from typing import Any
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -41,6 +24,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.mae import MAETrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
 
 logger = logging.getLogger(__name__)
 MAX_PATCH_SIZE = 8  # NOTE: actual patch_size <= max_patch_size

--- a/scripts/archived/dataset_saturation_check/full_latent_mim.py
+++ b/scripts/archived/dataset_saturation_check/full_latent_mim.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -36,6 +19,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/dataset_saturation_check/space_time_latent_mim.py
+++ b/scripts/archived/dataset_saturation_check/space_time_latent_mim.py
@@ -2,24 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.internal.common import build_common_components
@@ -37,6 +19,23 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/dino_v2_evals/dino_v2.py
+++ b/scripts/archived/dino_v2_evals/dino_v2.py
@@ -2,20 +2,6 @@
 
 import logging
 
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import WSD
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -34,6 +20,19 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import WSD
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/dino_v2_evals/dino_v2_eval.py
+++ b/scripts/archived/dino_v2_evals/dino_v2_eval.py
@@ -12,17 +12,6 @@ from dino_v2 import (
     build_train_module_config,
     build_visualize_config,
 )
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-
 from helios.data.constants import Modality
 from helios.internal.experiment import (
     CommonComponents,
@@ -37,6 +26,16 @@ from helios.train.callbacks import (
     HeliosWandBCallback,
 )
 from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
 
 
 def build_trainer_config(common: CommonComponents) -> TrainerConfig:

--- a/scripts/archived/dino_v2_evals/galileo.py
+++ b/scripts/archived/dino_v2_evals/galileo.py
@@ -2,10 +2,6 @@
 
 import logging
 
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import WSD
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -16,6 +12,9 @@ from helios.nn.latent_mim import LatentMIMConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import WSD
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/dino_v2_evals/galileo_evals.py
+++ b/scripts/archived/dino_v2_evals/galileo_evals.py
@@ -11,17 +11,6 @@ from galileo import (
     build_train_module_config,
     build_visualize_config,
 )
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-
 from helios.data.constants import Modality
 from helios.internal.common import build_common_components
 from helios.internal.experiment import (
@@ -37,6 +26,16 @@ from helios.train.callbacks import (
     HeliosWandBCallback,
 )
 from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
 
 
 def build_trainer_config(common: CommonComponents) -> TrainerConfig:

--- a/scripts/archived/dino_v2_evals/panopticon.py
+++ b/scripts/archived/dino_v2_evals/panopticon.py
@@ -2,10 +2,6 @@
 
 import logging
 
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import WSD
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -16,6 +12,9 @@ from helios.nn.latent_mim import LatentMIMConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import WSD
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/dino_v2_evals/panopticon_eval.py
+++ b/scripts/archived/dino_v2_evals/panopticon_eval.py
@@ -4,6 +4,21 @@ The eval.sh calls this script with all the different checkpoints we had for this
 model architecture related to fixed modality masking.
 """
 
+from helios.data.constants import Modality
+from helios.internal.common import build_common_components
+from helios.internal.experiment import (
+    CommonComponents,
+    main,
+)
+from helios.nn.flexihelios import (
+    PoolingType,
+)
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from olmo_core.train.callbacks import (
     BeakerCallback,
     CheckpointerCallback,
@@ -21,22 +36,6 @@ from panopticon import (
     build_train_module_config,
     build_visualize_config,
 )
-
-from helios.data.constants import Modality
-from helios.internal.common import build_common_components
-from helios.internal.experiment import (
-    CommonComponents,
-    main,
-)
-from helios.nn.flexihelios import (
-    PoolingType,
-)
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 
 
 def build_trainer_config(common: CommonComponents) -> TrainerConfig:

--- a/scripts/archived/evaluation_scripts/2025_05_15/galileo_eval.py
+++ b/scripts/archived/evaluation_scripts/2025_05_15/galileo_eval.py
@@ -3,23 +3,6 @@
 import logging
 from typing import Any
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -38,6 +21,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/fsdp_comparisons/base_fsdp_galileo.py
+++ b/scripts/archived/fsdp_comparisons/base_fsdp_galileo.py
@@ -6,24 +6,6 @@ It is a modified version of the base_debug_scripts/galileo.py script.
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-    ProfilerCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -41,6 +23,23 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+    ProfilerCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/fsdp_comparisons/base_fsdp_latent_mim.py
+++ b/scripts/archived/fsdp_comparisons/base_fsdp_latent_mim.py
@@ -2,6 +2,22 @@
 
 import logging
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.data.dataset import HeliosDatasetConfig
+from helios.data.normalize import Strategy
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, HeliosVisualizeConfig, main
+from helios.nn.flexihelios import EncoderConfig, PoolingType, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
+from helios.train.loss import LossConfig
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -19,23 +35,6 @@ from olmo_core.train.checkpoint import CheckpointerConfig
 from olmo_core.train.common import Duration, LoadStrategy
 from olmo_core.train.config import TrainerConfig
 from upath import UPath
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.data.dataset import HeliosDatasetConfig
-from helios.data.normalize import Strategy
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, HeliosVisualizeConfig, main
-from helios.nn.flexihelios import EncoderConfig, PoolingType, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
-from helios.train.loss import LossConfig
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/galileo_style_masking/galileo_base.py
+++ b/scripts/archived/galileo_style_masking/galileo_base.py
@@ -5,23 +5,6 @@ These Settings are meant to help you get quick results on a single GPU in minima
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
@@ -39,6 +22,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/galileo_style_masking/latent_mim_base.py
+++ b/scripts/archived/galileo_style_masking/latent_mim_base.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.internal.common import build_common_components
@@ -35,6 +18,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/inference_benchmarking/prepare_csv_from_results.py
+++ b/scripts/archived/inference_benchmarking/prepare_csv_from_results.py
@@ -4,7 +4,6 @@ import argparse
 
 import pandas as pd
 import wandb
-
 from helios.inference_benchmarking import constants
 from helios.inference_benchmarking.constants import PARAM_KEYS
 from helios.inference_benchmarking.data_models import RunParams

--- a/scripts/archived/joe/latent_mim.py
+++ b/scripts/archived/joe/latent_mim.py
@@ -2,26 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.internal.common import get_beaker_username
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import ConstantWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -52,6 +32,25 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.internal.common import get_beaker_username
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import ConstantWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/missing_modalities_training/base_missing_modalities_script.py
+++ b/scripts/archived/missing_modalities_training/base_missing_modalities_script.py
@@ -2,23 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.data.normalize import Strategy
@@ -35,6 +18,22 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/model_ladder/latent_mim_base_model_ladder_script.py
+++ b/scripts/archived/model_ladder/latent_mim_base_model_ladder_script.py
@@ -2,6 +2,22 @@
 
 import logging
 
+from helios.data.dataloader import HeliosDataLoaderConfig
+from helios.data.dataset import HeliosDatasetConfig
+from helios.data.normalize import Strategy
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, HeliosVisualizeConfig, main
+from helios.nn.flexihelios import EncoderConfig, PoolingType, PredictorConfig
+from helios.nn.latent_mim import LatentMIMConfig
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
+from helios.train.loss import LossConfig
+from helios.train.masking import MaskingConfig
+from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from olmo_core.config import DType
 from olmo_core.distributed.parallel.data_parallel import (
     DataParallelConfig,
@@ -19,23 +35,6 @@ from olmo_core.train.checkpoint import CheckpointerConfig
 from olmo_core.train.common import Duration, LoadStrategy
 from olmo_core.train.config import TrainerConfig
 from upath import UPath
-
-from helios.data.dataloader import HeliosDataLoaderConfig
-from helios.data.dataset import HeliosDatasetConfig
-from helios.data.normalize import Strategy
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, HeliosVisualizeConfig, main
-from helios.nn.flexihelios import EncoderConfig, PoolingType, PredictorConfig
-from helios.nn.latent_mim import LatentMIMConfig
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
-from helios.train.loss import LossConfig
-from helios.train.masking import MaskingConfig
-from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 
 logger = logging.getLogger(__name__)
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/parameter_sweeping/2025_03_21/latent_mim_base_script.py
+++ b/scripts/archived/parameter_sweeping/2025_03_21/latent_mim_base_script.py
@@ -2,24 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.dataloader import HeliosDataLoaderConfig
 from helios.data.dataset import HeliosDatasetConfig
 from helios.data.normalize import Strategy
@@ -37,6 +19,23 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 MAX_PATCH_SIZE = 8

--- a/scripts/archived/v0.2_sweep/latent_mim.py
+++ b/scripts/archived/v0.2_sweep/latent_mim.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -43,6 +24,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/v0.2_sweep/latent_mim_128.py
+++ b/scripts/archived/v0.2_sweep/latent_mim_128.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -43,6 +24,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/v0.2_sweep/latent_mim_128_naip.py
+++ b/scripts/archived/v0.2_sweep/latent_mim_128_naip.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -48,6 +29,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/v0.2_sweep/latent_mim_128_naip_custom.py
+++ b/scripts/archived/v0.2_sweep/latent_mim_128_naip_custom.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -48,6 +29,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/v0.2_sweep/latent_mim_large.py
+++ b/scripts/archived/v0.2_sweep/latent_mim_large.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -43,6 +24,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/v0.2_sweep/latent_mim_large_alldata.py
+++ b/scripts/archived/v0.2_sweep/latent_mim_large_alldata.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -43,6 +24,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/v0.2_sweep/latent_mim_no_worldcover.py
+++ b/scripts/archived/v0.2_sweep/latent_mim_no_worldcover.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -43,6 +24,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/v0.2_sweep/latent_mim_presto_osm.py
+++ b/scripts/archived/v0.2_sweep/latent_mim_presto_osm.py
@@ -2,25 +2,6 @@
 
 import logging
 
-from olmo_core.config import DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-from upath import UPath
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -43,6 +24,24 @@ from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from helios.train.loss import LossConfig
 from helios.train.masking import MaskingConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
+from olmo_core.config import DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
+from upath import UPath
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/v0_sweep/contrastive_latent_mim.py
+++ b/scripts/archived/v0_sweep/contrastive_latent_mim.py
@@ -1,5 +1,7 @@
 """Script for v0 sweep for Contrastive Latent MIM."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/v0_sweep/contrastive_latent_mim_st.py
+++ b/scripts/archived/v0_sweep/contrastive_latent_mim_st.py
@@ -1,5 +1,7 @@
 """Script for v0 sweep for Contrastive Latent MIM."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/v0_sweep/galileo.py
+++ b/scripts/archived/v0_sweep/galileo.py
@@ -1,5 +1,7 @@
 """Script for v0 sweep for Galileo."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/v0_sweep/galileo_debug.py
+++ b/scripts/archived/v0_sweep/galileo_debug.py
@@ -2,6 +2,19 @@
 
 import logging
 
+from helios.data.concat import HeliosConcatDatasetConfig
+from helios.data.dataset import HeliosDatasetConfig
+from helios.internal.common import build_common_components
+from helios.internal.experiment import CommonComponents, main
+from helios.nn.flexihelios import (
+    PoolingType,
+)
+from helios.train.callbacks import (
+    DownstreamEvaluatorCallbackConfig,
+    HeliosSpeedMonitorCallback,
+    HeliosWandBCallback,
+)
+from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 from olmo_core.config import DType
 from olmo_core.train.callbacks import (
     BeakerCallback,
@@ -20,20 +33,6 @@ from shared import (
     build_train_module_config_builder,
     build_visualize_config,
 )
-
-from helios.data.concat import HeliosConcatDatasetConfig
-from helios.data.dataset import HeliosDatasetConfig
-from helios.internal.common import build_common_components
-from helios.internal.experiment import CommonComponents, main
-from helios.nn.flexihelios import (
-    PoolingType,
-)
-from helios.train.callbacks import (
-    DownstreamEvaluatorCallbackConfig,
-    HeliosSpeedMonitorCallback,
-    HeliosWandBCallback,
-)
-from helios.train.callbacks.evaluator_callback import DownstreamTaskConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/archived/v0_sweep/galileo_st.py
+++ b/scripts/archived/v0_sweep/galileo_st.py
@@ -1,5 +1,7 @@
 """Script for v0 sweep for Galileo."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/v0_sweep/latent_mim.py
+++ b/scripts/archived/v0_sweep/latent_mim.py
@@ -1,5 +1,7 @@
 """Script for v0 sweep for Latent MIM."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/v0_sweep/latent_mim_st.py
+++ b/scripts/archived/v0_sweep/latent_mim_st.py
@@ -1,5 +1,7 @@
 """Script for v0 sweep for Latent MIM."""
 
+from helios.internal.common import build_common_components
+from helios.internal.experiment import main
 from shared import (
     build_dataloader_config,
     build_dataset_config,
@@ -8,9 +10,6 @@ from shared import (
     build_trainer_config,
     build_visualize_config,
 )
-
-from helios.internal.common import build_common_components
-from helios.internal.experiment import main
 
 if __name__ == "__main__":
     main(

--- a/scripts/archived/v0_sweep/shared.py
+++ b/scripts/archived/v0_sweep/shared.py
@@ -3,24 +3,6 @@
 import logging
 from collections.abc import Callable
 
-from olmo_core.config import Config, DType
-from olmo_core.distributed.parallel.data_parallel import (
-    DataParallelConfig,
-    DataParallelType,
-)
-from olmo_core.optim import AdamWConfig
-from olmo_core.optim.scheduler import CosWithWarmup
-from olmo_core.train.callbacks import (
-    BeakerCallback,
-    CheckpointerCallback,
-    ConfigSaverCallback,
-    GarbageCollectorCallback,
-    GPUMemoryMonitorCallback,
-)
-from olmo_core.train.checkpoint import CheckpointerConfig
-from olmo_core.train.common import Duration, LoadStrategy
-from olmo_core.train.config import TrainerConfig
-
 from helios.data.concat import HeliosConcatDatasetConfig
 from helios.data.constants import Modality
 from helios.data.dataloader import HeliosDataLoaderConfig
@@ -50,6 +32,23 @@ from helios.train.train_module.contrastive_latentmim import (
 from helios.train.train_module.galileo import GalileoTrainModuleConfig
 from helios.train.train_module.latent_mim import LatentMIMTrainModuleConfig
 from helios.train.train_module.train_module import HeliosTrainModuleConfig
+from olmo_core.config import Config, DType
+from olmo_core.distributed.parallel.data_parallel import (
+    DataParallelConfig,
+    DataParallelType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.optim.scheduler import CosWithWarmup
+from olmo_core.train.callbacks import (
+    BeakerCallback,
+    CheckpointerCallback,
+    ConfigSaverCallback,
+    GarbageCollectorCallback,
+    GPUMemoryMonitorCallback,
+)
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.common import Duration, LoadStrategy
+from olmo_core.train.config import TrainerConfig
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/tools/check_token_budget.py
+++ b/scripts/tools/check_token_budget.py
@@ -4,7 +4,6 @@ import argparse
 
 import pandas as pd
 import torch
-
 from helios.data.constants import Modality
 from helios.data.dataset import HeliosSample
 

--- a/scripts/tools/compute_eval_dataset_minmax.py
+++ b/scripts/tools/compute_eval_dataset_minmax.py
@@ -22,9 +22,6 @@ from pathlib import Path
 import numpy as np
 import torch
 from einops import rearrange
-from tqdm import tqdm
-from upath import UPath
-
 from helios.evals.datasets import (
     BREIZHCROPS_DIR,
     FLOODS_DIR,
@@ -37,6 +34,8 @@ from helios.evals.datasets.constants import (
     EVAL_S1_BAND_NAMES,
     EVAL_S2_BAND_NAMES,
 )
+from tqdm import tqdm
+from upath import UPath
 
 
 def _process_image_file(file_path, modality_type):

--- a/scripts/tools/compute_rslearn_dataset_band_stats.py
+++ b/scripts/tools/compute_rslearn_dataset_band_stats.py
@@ -5,11 +5,6 @@ import json
 
 import torch
 from einops import rearrange
-from rslearn.dataset.dataset import Dataset as RslearnDataset
-from torch.utils.data import DataLoader
-from tqdm import tqdm
-from upath import UPath
-
 from helios.data.constants import YEAR_NUM_TIMESTEPS
 from helios.data.constants import Modality as DataModality
 from helios.data.utils import convert_to_db
@@ -17,6 +12,10 @@ from helios.evals.datasets.rslearn_dataset import (
     RSLEARN_TO_HELIOS,
     build_rslearn_model_dataset,
 )
+from rslearn.dataset.dataset import Dataset as RslearnDataset
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from upath import UPath
 
 
 def get_bands_by_modality(input_layers: list[str]) -> dict[str, list[str]]:


### PR DESCRIPTION
- Fixed 169 linting errors across scripts and module files
- Removed unused imports (os, json, sys, typing annotations, etc.)
- Standardized import ordering per isort rules
- Applied automatic code style fixes per project ruff configuration