### PR TITLE
Fix evaluation when loading checkpoint

### DIFF
--- a/olmoearth_pretrain/internal/experiment.py
+++ b/olmoearth_pretrain/internal/experiment.py
@@ -298,7 +298,13 @@ def evaluate(config: OlmoEarthExperimentConfig) -> None:
     device = get_default_device()
     model = model.to(device)
     data_loader = MockOlmoEarthDataLoader()
-    train_module = MockLatentMIMTrainModule()
+
+    # Handle case where we're loading OlmoEarth distributed checkpoint for eval
+    if config.trainer.load_path is not None:
+        train_module = config.train_module.build(model)
+    else:
+        train_module = MockLatentMIMTrainModule()
+
     train_module.model = model
     trainer = config.trainer.build(train_module, data_loader)
     # Record the config to W&B/Comet and each checkpoint dir.


### PR DESCRIPTION
In the previous refactor, I switched to `MockLatentMIMTrainModule()`, which doesn’t handle OlmoEarth distributed checkpoints properly. This fix first checks whether `load_path` is None or not first and then selects the right TrainModule. Without this fix, the OlmoEarth model will be randomly initialized and not using the checkpoint.