### PR TITLE
fix patchified data dtype

### DIFF
--- a/olmoearth_pretrain/nn/flexi_vit.py
+++ b/olmoearth_pretrain/nn/flexi_vit.py
@@ -497,7 +497,7 @@ class MultiModalPatchEmbeddings(nn.Module):
             else:
                 mask_shape = token_mask.shape + (self.embedding_size,)
                 patchified_data = torch.zeros(
-                    mask_shape, dtype=token_mask.dtype, device=token_mask.device
+                    mask_shape, dtype=modality_data.dtype, device=token_mask.device
                 )
 
             modality_tokens.append(patchified_data)


### PR DESCRIPTION
Previously, if we had no online encoder values we would construct tokens using the same dtype as the masks. However, masks are long and we want the tokens to be floats.

This made runs [fail](https://beaker.allen.ai/orgs/ai2/workspaces/earth-systems/work/01KF1K5YFAEZ3Y81X88183V5AQ/logs?jobId=01KF1K5YTZ1VHW60154R4HBHKH) with the following error:

<details>
<summary>logs are long so they are collapsed</summary>

```
2026-01-15T20:44:03.690Z [2026-01-15 20:44:03] CRITICAL [olmo_core.utils:380, rank=1] Uncaught RuntimeError: linalg.vector_norm: Expected a floating point or complex tensor as input. Got Long
2026-01-15T20:44:03.691Z ╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/scripts/official/base.py:59 in <module>                                       │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   56                                                                                             │
2026-01-15T20:44:03.691Z │   57                                                                                             │
2026-01-15T20:44:03.691Z │   58 if __name__ == "__main__":                                                                  │
2026-01-15T20:44:03.691Z │ ❱ 59 │   main(                                                                                   │
2026-01-15T20:44:03.691Z │   60 │   │   common_components_builder=build_common_components,                                  │
2026-01-15T20:44:03.691Z │   61 │   │   model_config_builder=build_model_config,                                            │
2026-01-15T20:44:03.691Z │   62 │   │   train_module_config_builder=build_train_module_config,                              │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/olmoearth_pretrain/internal/experiment.py:563 in main                         │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   560 │   │   │   overrides=overrides,                                                           │
2026-01-15T20:44:03.691Z │   561 │   │   )                                                                                  │
2026-01-15T20:44:03.691Z │   562 │                                                                                          │
2026-01-15T20:44:03.691Z │ ❱ 563 │   cmd.run(config)                                                                        │
2026-01-15T20:44:03.691Z │   564                                                                                            │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/olmoearth_pretrain/internal/experiment.py:436 in run                          │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   433 │   │   │   visualize(config)                                                              │
2026-01-15T20:44:03.691Z │   434 │   │   elif self == SubCmd.train:                                                         │
2026-01-15T20:44:03.691Z │   435 │   │   │   try:                                                                           │
2026-01-15T20:44:03.691Z │ ❱ 436 │   │   │   │   train(config)                                                              │
2026-01-15T20:44:03.691Z │   437 │   │   │   finally:                                                                       │
2026-01-15T20:44:03.691Z │   438 │   │   │   │   teardown_training_environment()                                            │
2026-01-15T20:44:03.691Z │   439 │   │   elif self == SubCmd.evaluate:                                                      │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/olmoearth_pretrain/internal/experiment.py:287 in train                        │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   284 │   config_dict = config.as_config_dict()                                                  │
2026-01-15T20:44:03.691Z │   285 │   cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict                   │
2026-01-15T20:44:03.691Z │   286 │   cast(ConfigSaverCallback, trainer.callbacks["config_saver"]).config = config_dict      │
2026-01-15T20:44:03.691Z │ ❱ 287 │   trainer.fit()                                                                          │
2026-01-15T20:44:03.691Z │   288                                                                                            │
2026-01-15T20:44:03.691Z │   289                                                                                            │
2026-01-15T20:44:03.691Z │   290 def evaluate(config: OlmoEarthExperimentConfig) -> None:                                   │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/.venv/lib/python3.11/site-packages/olmo_core/train/trainer.py:699 in fit      │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │    696 │   │   │                                                                                 │
2026-01-15T20:44:03.691Z │    697 │   │   │   # Iterate over epochs until done.                                             │
2026-01-15T20:44:03.691Z │    698 │   │   │   while not self.training_complete:                                             │
2026-01-15T20:44:03.691Z │ ❱  699 │   │   │   │   self._fit_epoch()                                                         │
2026-01-15T20:44:03.691Z │    700 │   │   except BaseException as exc:                                                      │
2026-01-15T20:44:03.691Z │    701 │   │   │   self._error = exc                                                             │
2026-01-15T20:44:03.691Z │    702 │   │   │   log.error(f"Training failed due to:\n{type(exc).__name__}: {exc}")            │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/.venv/lib/python3.11/site-packages/olmo_core/train/trainer.py:1331 in _fit_ep │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   1328 │   │   │   for callback in self._iter_callbacks():                                       │
2026-01-15T20:44:03.691Z │   1329 │   │   │   │   callback.pre_step(batch)                                                  │
2026-01-15T20:44:03.691Z │   1330 │   │   │                                                                                 │
2026-01-15T20:44:03.691Z │ ❱ 1331 │   │   │   self.train_module.train_batch(batch)                                          │
2026-01-15T20:44:03.691Z │   1332 │   │   │                                                                                 │
2026-01-15T20:44:03.691Z │   1333 │   │   │   for callback in self._iter_callbacks():                                       │
2026-01-15T20:44:03.691Z │   1334 │   │   │   │   callback.pre_optim_step()                                                 │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/olmoearth_pretrain/train/train_module/contrastive_latentmim.py:219 in train_b │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   216 │   │   │   │   )                                                                          │
2026-01-15T20:44:03.691Z │   217 │   │   │   │   # Run Encoder and decoder on the augmented input                           │
2026-01-15T20:44:03.691Z │   218 │   │   │   │   loss_a, latent_a, decoded_a, target_output_a, pooled_a = (                 │
2026-01-15T20:44:03.691Z │ ❱ 219 │   │   │   │   │   self.model_forward(masked_batch_a, patch_size, self.token_exit_cfg)    │
2026-01-15T20:44:03.691Z │   220 │   │   │   │   )                                                                          │
2026-01-15T20:44:03.691Z │   221 │   │   │   │   loss_b, latent_b, decoded_b, target_output_b, pooled_b = (                 │
2026-01-15T20:44:03.691Z │   222 │   │   │   │   │   self.model_forward(masked_batch_b, patch_size, self.token_exit_cfg)    │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/olmoearth_pretrain/train/train_module/contrastive_latentmim.py:307 in model_f │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   304 │   │   │   │   │   token_exit_cfg=token_exit_cfg,                                         │
2026-01-15T20:44:03.691Z │   305 │   │   │   │   )                                                                          │
2026-01-15T20:44:03.691Z │   306 │   │   │   │   target_output, _, _ = unpack_encoder_output(output_dict)                   │
2026-01-15T20:44:03.691Z │ ❱ 307 │   │   │   loss = self.loss_fn(decoded, target_output)                                    │
2026-01-15T20:44:03.691Z │   308 │   │   │   if self.mae_loss is not None and reconstructed is not None:                    │
2026-01-15T20:44:03.691Z │   309 │   │   │   │   loss += self.mae_loss.compute(reconstructed, batch)                        │
2026-01-15T20:44:03.691Z │   310 │   │   │   return loss, latent, decoded, target_output, latent_projected_and_pooled       │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/olmoearth_pretrain/train/train_module/contrastive_latentmim.py:176 in loss_fn │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   173 │                                                                                          │
2026-01-15T20:44:03.691Z │   174 │   def loss_fn(self, pred: Any, targets: Any) -> torch.Tensor:                            │
2026-01-15T20:44:03.691Z │   175 │   │   """Compute the loss between the predicted and target tensors."""                   │
2026-01-15T20:44:03.691Z │ ❱ 176 │   │   return self.base_loss.compute(pred, targets)                                       │
2026-01-15T20:44:03.691Z │   177 │                                                                                          │
2026-01-15T20:44:03.691Z │   178 │   def train_batch(                                                                       │
2026-01-15T20:44:03.691Z │   179 │   │   self, batch: tuple[int, OlmoEarthSample], dry_run: bool = False                    │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/olmoearth_pretrain/train/loss.py:335 in compute                               │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   332 │   │   │   │   pred = (pred - pred_mu) / (pred_std + 1e-4)                                │
2026-01-15T20:44:03.691Z │   333 │   │   │                                                                                  │
2026-01-15T20:44:03.691Z │   334 │   │   │   pred = F.normalize(pred, p=2, dim=-1)                                          │
2026-01-15T20:44:03.691Z │ ❱ 335 │   │   │   target = F.normalize(target, p=2, dim=-1)                                      │
2026-01-15T20:44:03.691Z │   336 │   │   │                                                                                  │
2026-01-15T20:44:03.691Z │   337 │   │   │   count = (all_masks == MaskValue.DECODER.value).sum(dim=-1)                     │
2026-01-15T20:44:03.691Z │   338 │   │   │   losses = []                                                                    │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/.venv/lib/python3.11/site-packages/torch/nn/functional.py:5486 in normalize   │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   5483 │   │   │   normalize, (input, out), input, p=p, dim=dim, eps=eps, out=out                │
2026-01-15T20:44:03.691Z │   5484 │   │   )                                                                                 │
2026-01-15T20:44:03.691Z │   5485 │   if out is None:                                                                       │
2026-01-15T20:44:03.691Z │ ❱ 5486 │   │   denom = input.norm(p, dim, keepdim=True).clamp_min(eps).expand_as(input)          │
2026-01-15T20:44:03.691Z │   5487 │   │   return input / denom                                                              │
2026-01-15T20:44:03.691Z │   5488 │   else:                                                                                 │
2026-01-15T20:44:03.691Z │   5489 │   │   denom = input.norm(p, dim, keepdim=True).clamp_min_(eps).expand_as(input)         │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/.venv/lib/python3.11/site-packages/torch/_tensor.py:894 in norm               │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │    891 │   │   │   return handle_torch_function(                                                 │
2026-01-15T20:44:03.691Z │    892 │   │   │   │   Tensor.norm, (self,), self, p=p, dim=dim, keepdim=keepdim, dtype=dtype    │
2026-01-15T20:44:03.691Z │    893 │   │   │   )                                                                             │
2026-01-15T20:44:03.691Z │ ❱  894 │   │   return torch.norm(self, p, dim, keepdim, dtype=dtype)                             │
2026-01-15T20:44:03.691Z │    895 │                                                                                         │
2026-01-15T20:44:03.691Z │    896 │   def solve(self, other):                                                               │
2026-01-15T20:44:03.691Z │    897 │   │   from torch._linalg_utils import solve                                             │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │ /olmo-core-runtime/.venv/lib/python3.11/site-packages/torch/functional.py:1849 in norm           │
2026-01-15T20:44:03.691Z │                                                                                                  │
2026-01-15T20:44:03.691Z │   1846 │   │   │   # NB. p should be Union[str, number], not Optional!                           │
2026-01-15T20:44:03.691Z │   1847 │   │   │   _p = 2.0 if p is None else p                                                  │
2026-01-15T20:44:03.691Z │   1848 │   │   │   if out is None:                                                               │
2026-01-15T20:44:03.691Z │ ❱ 1849 │   │   │   │   return torch.linalg.vector_norm(input, _p, _dim, keepdim, dtype=dtype)    │
2026-01-15T20:44:03.691Z │   1850 │   │   │   else:                                                                         │
2026-01-15T20:44:03.691Z │   1851 │   │   │   │   return torch.linalg.vector_norm(                                          │
2026-01-15T20:44:03.691Z │   1852 │   │   │   │   │   input, _p, _dim, keepdim, dtype=dtype, out=out                        │
2026-01-15T20:44:03.691Z ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
2026-01-15T20:44:03.691Z RuntimeError: linalg.vector_norm: Expected a floating point or complex tensor as input. Got Long
```

</details>

TL;DR: the targets are long, not floats like we want them to be

Why didn't this get triggered before? Because thanks to our `unmask` bug, everything was given a value of 0 so we never entered this branch. 

Confirmed this change allows runs to progress: https://beaker.allen.ai/orgs/ai2/workspaces/earth-systems/work/01KF1TM9QZVN5F52TBEFNN05KS?taskId=01KF1TM9ZP5S10Q1E2MEWJFZRC&jobId=01KF1TMA41GER294RNS50V44DM