### PR TITLE
Rank max learning rate

### DIFF
--- a/olmoearth_pretrain/evals/linear_probe.py
+++ b/olmoearth_pretrain/evals/linear_probe.py
@@ -9,7 +9,6 @@ from logging import getLogger
 
 import numpy as np
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
@@ -42,15 +41,6 @@ def get_rank_lr(rank: int, world_size: int) -> float | None:
     if rank >= len(RANK_MAX_LRS):
         return None
     return RANK_MAX_LRS[rank]
-
-
-def all_reduce_max(value: float, device: torch.device) -> float:
-    """All-reduce a scalar value with MAX operation across ranks."""
-    if not is_distributed():
-        return value
-    tensor = torch.tensor([value], device=device, dtype=torch.float32)
-    dist.all_reduce(tensor, op=dist.ReduceOp.MAX)
-    return tensor.item()
 
 
 class ProbeType(StrEnum):
@@ -187,7 +177,9 @@ def train_and_eval_probe(
             use_rank_max = False
 
     if use_rank_max:
-        effective_lr = get_rank_lr(rank, world_size)
+        rank_lr = get_rank_lr(rank, world_size)
+        assert rank_lr is not None
+        effective_lr = rank_lr
         logger.info(
             f"Rank-max LR enabled: rank {rank}/{world_size} using lr={effective_lr:.6f} "
             f"(sweep LRs: {RANK_MAX_LRS})"
@@ -398,34 +390,6 @@ def train_and_eval_probe(
         )
         if n_bootstrap == 0:
             logger.info(f"Test result: {test_result}")
-
-    # When using rank-max LR, aggregate results via all_reduce MAX
-    if use_rank_max:
-        local_val = final_val_result.primary
-        max_val_primary = all_reduce_max(local_val, device)
-        if max_val_primary > local_val:
-            logger.info(
-                f"Rank {rank}: local val={local_val:.4f}, max across ranks={max_val_primary:.4f}"
-            )
-        else:
-            logger.info(
-                f"Rank {rank}: this rank achieved max val={local_val:.4f} (lr={effective_lr:.6f})"
-            )
-        # Update the primary metric, keep other metrics from this rank
-        updated_metrics = dict(final_val_result.metrics)
-        for k, v in updated_metrics.items():
-            if v == local_val:
-                updated_metrics[k] = max_val_primary
-        final_val_result = EvalResult(primary=max_val_primary, metrics=updated_metrics)
-
-        if test_result is not None:
-            local_test = test_result.primary
-            max_test_primary = all_reduce_max(local_test, device)
-            updated_test_metrics = dict(test_result.metrics)
-            for k, v in updated_test_metrics.items():
-                if v == local_test:
-                    updated_test_metrics[k] = max_test_primary
-            test_result = EvalResult(primary=max_test_primary, metrics=updated_test_metrics)
 
     return EvalTaskResult(
         val_result=final_val_result,

--- a/olmoearth_pretrain/train/callbacks/evaluator_callback.py
+++ b/olmoearth_pretrain/train/callbacks/evaluator_callback.py
@@ -80,6 +80,7 @@ class DownstreamTaskConfig:
     probe_lr: float | None = None
     probe_batch_size: int = 32
     linear_probe_eval_interval: int = 50  # calculate val results every N epochs
+    rank_max_lr: bool = False  # each rank uses different LR, take max across ranks
     # FT
     ft_lr: float | None = None
     ft_batch_size: int = 32
@@ -103,6 +104,9 @@ class DownstreamTaskConfig:
     quantize_embeddings: bool = False
     # Reduce embedding dimensionality via PCA (None = no reduction)
     embedding_dim: int | None = None
+    # Rank-max LR: each rank uses a different LR and we take max across ranks
+    # This effectively gives a free LR sweep during evaluation
+    rank_max_lr: bool = False
 
 
 class DownstreamEvaluator:
@@ -144,6 +148,7 @@ class DownstreamEvaluator:
         self.input_layers = task.input_layers
         self.probe_lr = task.probe_lr
         self.probe_batch_size = task.probe_batch_size
+        self.rank_max_lr = task.rank_max_lr
         self.ft_lr = task.ft_lr
         self.ft_batch_size = task.ft_batch_size
         self.finetune_seed = task.finetune_seed
@@ -213,6 +218,7 @@ class DownstreamEvaluator:
                     probe_type=self.probe_type,
                     lr=self.probe_lr,
                     select_final_test_miou_based_on_epoch_of_max_val_miou=self.select_final_test_miou_based_on_epoch_of_max_val_miou,
+                    rank_max_lr=self.rank_max_lr,
                 )
                 if self.eval_mode == EvalMode.LINEAR_PROBE
                 else None

--- a/olmoearth_pretrain/train/callbacks/evaluator_callback.py
+++ b/olmoearth_pretrain/train/callbacks/evaluator_callback.py
@@ -13,7 +13,7 @@ from typing import Any
 import numpy as np
 import torch
 from olmo_core.train.callbacks.callback import Callback, CallbackConfig
-from olmo_core.train.common import Duration
+from olmo_core.train.common import Duration, ReduceType
 from olmo_core.train.trainer import Trainer
 from torch.utils.data import DataLoader
 
@@ -104,9 +104,6 @@ class DownstreamTaskConfig:
     quantize_embeddings: bool = False
     # Reduce embedding dimensionality via PCA (None = no reduction)
     embedding_dim: int | None = None
-    # Rank-max LR: each rank uses a different LR and we take max across ranks
-    # This effectively gives a free LR sweep during evaluation
-    rank_max_lr: bool = False
 
 
 class DownstreamEvaluator:
@@ -507,11 +504,20 @@ def _log_eval_result_to_wandb(
 def _record_eval_result(
     trainer: Trainer, prefix: str, name: str, result: EvalResult
 ) -> None:
-    """Record an EvalResult to trainer metrics."""
+    """Record an EvalResult to trainer metrics.
+
+    Uses ReduceType.max so that when ranks run different LRs (rank-max LR),
+    the best result across ranks is reported automatically.
+    """
     for metric_name, metric_value in result.metrics.items():
-        trainer.record_metric(f"{prefix}/{name}/{metric_name}", metric_value)
-    # Also record primary metric for backward compatibility
-    trainer.record_metric(f"{prefix}/{name}", result.primary)
+        trainer.record_metric(
+            f"{prefix}/{name}/{metric_name}",
+            metric_value,
+            reduce_type=ReduceType.max,
+        )
+    trainer.record_metric(
+        f"{prefix}/{name}", result.primary, reduce_type=ReduceType.max
+    )
 
 
 @dataclass

--- a/scripts/rank_max_lr_comparison.sh
+++ b/scripts/rank_max_lr_comparison.sh
@@ -1,20 +1,26 @@
 #!/bin/bash
 # Comparison experiments for rank_max_lr feature
-# Run MADOS eval every 500 steps for 2000 steps total
+# Run MADOS eval every 500 steps for 8000 steps total
 # Requires 8 GPUs for rank_max_lr to be active
 
 # Baseline (without rank_max_lr)
 python scripts/official/base.py launch mados-baseline ai2/jupiter-cirrascale-2 \
-  --trainer.max_duration='Duration.steps(2000)' \
+  --trainer.max_duration.value=8000 \
+  --trainer.max_duration.unit=steps \
   --trainer.callbacks.downstream_evaluator.tasks_to_run='["mados"]' \
-  --trainer.callbacks.downstream_evaluator.tasks.mados.eval_interval='Duration.steps(500)' \
+  --trainer.callbacks.downstream_evaluator.tasks.mados.eval_interval.value=500 \
+  --trainer.callbacks.downstream_evaluator.tasks.mados.eval_interval.unit=steps \
   --trainer.callbacks.downstream_evaluator.tasks.mados.rank_max_lr=False \
-  --launch.num_gpus=8
+  --launch.num_gpus=8 \
+  --launch.priority=low
 
 # With rank_max_lr (each GPU uses different LR, take max)
 python scripts/official/base.py launch mados-rank-max-lr ai2/jupiter-cirrascale-2 \
-  --trainer.max_duration='Duration.steps(2000)' \
+  --trainer.max_duration.value=8000 \
+  --trainer.max_duration.unit=steps \
   --trainer.callbacks.downstream_evaluator.tasks_to_run='["mados"]' \
-  --trainer.callbacks.downstream_evaluator.tasks.mados.eval_interval='Duration.steps(500)' \
+  --trainer.callbacks.downstream_evaluator.tasks.mados.eval_interval.value=500 \
+  --trainer.callbacks.downstream_evaluator.tasks.mados.eval_interval.unit=steps \
   --trainer.callbacks.downstream_evaluator.tasks.mados.rank_max_lr=True \
-  --launch.num_gpus=8
+  --launch.num_gpus=8 \
+  --launch.priority=low

--- a/scripts/rank_max_lr_comparison.sh
+++ b/scripts/rank_max_lr_comparison.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Comparison experiments for rank_max_lr feature
+# Run MADOS eval every 500 steps for 2000 steps total
+# Requires 8 GPUs for rank_max_lr to be active
+
+# Baseline (without rank_max_lr)
+python scripts/official/base.py launch mados-baseline ai2/jupiter-cirrascale-2 \
+  --trainer.max_duration='Duration.steps(2000)' \
+  --trainer.callbacks.downstream_evaluator.tasks_to_run='["mados"]' \
+  --trainer.callbacks.downstream_evaluator.tasks.mados.eval_interval='Duration.steps(500)' \
+  --trainer.callbacks.downstream_evaluator.tasks.mados.rank_max_lr=False \
+  --launch.num_gpus=8
+
+# With rank_max_lr (each GPU uses different LR, take max)
+python scripts/official/base.py launch mados-rank-max-lr ai2/jupiter-cirrascale-2 \
+  --trainer.max_duration='Duration.steps(2000)' \
+  --trainer.callbacks.downstream_evaluator.tasks_to_run='["mados"]' \
+  --trainer.callbacks.downstream_evaluator.tasks.mados.eval_interval='Duration.steps(500)' \
+  --trainer.callbacks.downstream_evaluator.tasks.mados.rank_max_lr=True \
+  --launch.num_gpus=8


### PR DESCRIPTION
Add `rank_max_lr` to enable per-rank learning rates for linear probe evaluation, providing a free learning rate sweep during in-loop evaluations.

---
<p><a href="https://cursor.com/agents/bc-8cdbaf45-fd79-40c3-ac33-f7f2f6a57d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cdbaf45-fd79-40c3-ac33-f7f2f6a57d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

