### PR TITLE
Fix WorldCereal data by using SINGLE_COMPOSITE and setting correct NODATA

### DIFF
--- a/data/rslearn_dataset_configs/config_worldcereal.json
+++ b/data/rslearn_dataset_configs/config_worldcereal.json
@@ -6,13 +6,19 @@
           "bands": [
             "tc-annual-temporarycrops-classification"
           ],
-          "dtype": "float32"
+          "dtype": "float32",
+          "nodata_vals": [
+            255.0
+          ]
         }
       ],
       "data_source": {
         "class_path": "rslearn.data_sources.worldcereal.WorldCereal",
         "init_args": {
           "worldcereal_dir": "source_data/worldcereal/"
+        },
+        "query_config": {
+          "space_mode": "SINGLE_COMPOSITE"
         }
       },
       "resampling_method": "nearest",
@@ -24,13 +30,19 @@
           "bands": [
             "tc-maize-main-irrigation-classification"
           ],
-          "dtype": "float32"
+          "dtype": "float32",
+          "nodata_vals": [
+            255.0
+          ]
         }
       ],
       "data_source": {
         "class_path": "rslearn.data_sources.worldcereal.WorldCereal",
         "init_args": {
           "worldcereal_dir": "source_data/worldcereal/"
+        },
+        "query_config": {
+          "space_mode": "SINGLE_COMPOSITE"
         }
       },
       "resampling_method": "nearest",
@@ -42,13 +54,19 @@
           "bands": [
             "tc-maize-main-maize-classification"
           ],
-          "dtype": "float32"
+          "dtype": "float32",
+          "nodata_vals": [
+            255.0
+          ]
         }
       ],
       "data_source": {
         "class_path": "rslearn.data_sources.worldcereal.WorldCereal",
         "init_args": {
           "worldcereal_dir": "source_data/worldcereal/"
+        },
+        "query_config": {
+          "space_mode": "SINGLE_COMPOSITE"
         }
       },
       "resampling_method": "nearest",
@@ -60,13 +78,19 @@
           "bands": [
             "tc-maize-second-irrigation-classification"
           ],
-          "dtype": "float32"
+          "dtype": "float32",
+          "nodata_vals": [
+            255.0
+          ]
         }
       ],
       "data_source": {
         "class_path": "rslearn.data_sources.worldcereal.WorldCereal",
         "init_args": {
           "worldcereal_dir": "source_data/worldcereal/"
+        },
+        "query_config": {
+          "space_mode": "SINGLE_COMPOSITE"
         }
       },
       "resampling_method": "nearest",
@@ -78,13 +102,19 @@
           "bands": [
             "tc-maize-second-maize-classification"
           ],
-          "dtype": "float32"
+          "dtype": "float32",
+          "nodata_vals": [
+            255.0
+          ]
         }
       ],
       "data_source": {
         "class_path": "rslearn.data_sources.worldcereal.WorldCereal",
         "init_args": {
           "worldcereal_dir": "source_data/worldcereal/"
+        },
+        "query_config": {
+          "space_mode": "SINGLE_COMPOSITE"
         }
       },
       "resampling_method": "nearest",
@@ -96,13 +126,19 @@
           "bands": [
             "tc-springcereals-springcereals-classification"
           ],
-          "dtype": "float32"
+          "dtype": "float32",
+          "nodata_vals": [
+            255.0
+          ]
         }
       ],
       "data_source": {
         "class_path": "rslearn.data_sources.worldcereal.WorldCereal",
         "init_args": {
           "worldcereal_dir": "source_data/worldcereal/"
+        },
+        "query_config": {
+          "space_mode": "SINGLE_COMPOSITE"
         }
       },
       "resampling_method": "nearest",
@@ -114,13 +150,19 @@
           "bands": [
             "tc-wintercereals-irrigation-classification"
           ],
-          "dtype": "float32"
+          "dtype": "float32",
+          "nodata_vals": [
+            255.0
+          ]
         }
       ],
       "data_source": {
         "class_path": "rslearn.data_sources.worldcereal.WorldCereal",
         "init_args": {
           "worldcereal_dir": "source_data/worldcereal/"
+        },
+        "query_config": {
+          "space_mode": "SINGLE_COMPOSITE"
         }
       },
       "resampling_method": "nearest",
@@ -132,13 +174,19 @@
           "bands": [
             "tc-wintercereals-wintercereals-classification"
           ],
-          "dtype": "float32"
+          "dtype": "float32",
+          "nodata_vals": [
+            255.0
+          ]
         }
       ],
       "data_source": {
         "class_path": "rslearn.data_sources.worldcereal.WorldCereal",
         "init_args": {
           "worldcereal_dir": "source_data/worldcereal/"
+        },
+        "query_config": {
+          "space_mode": "SINGLE_COMPOSITE"
         }
       },
       "resampling_method": "nearest",

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/cdl.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/cdl.py
@@ -8,6 +8,7 @@ import tqdm
 from rslearn.data_sources import Item
 from rslearn.dataset import Dataset, Window
 from rslearn.utils.mp import star_imap_unordered
+from rslearn.utils.raster_array import RasterArray
 from upath import UPath
 
 from olmoearth_pretrain.data.constants import Modality, TimeSpan
@@ -46,7 +47,7 @@ def convert_cdl(window: Window, olmoearth_path: UPath) -> None:
     raster_dir = window.get_raster_dir(LAYER_NAME, band_set.bands)
     image = GEOTIFF_RASTER_FORMAT.decode_raster(
         raster_dir, window.projection, window.bounds
-    )
+    ).get_chw_array()
 
     # Skip if there are any background/nodata.
     if image.min() == 0:
@@ -64,7 +65,7 @@ def convert_cdl(window: Window, olmoearth_path: UPath) -> None:
         path=dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=image,
+        raster=RasterArray(chw_array=image),
         fname=dst_fname.name,
     )
     metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/era5.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/era5.py
@@ -12,6 +12,7 @@ import tqdm
 from rslearn.data_sources import Item
 from rslearn.dataset import Dataset, Window
 from rslearn.utils.mp import star_imap_unordered
+from rslearn.utils.raster_array import RasterArray
 from rslearn.utils.raster_format import GeotiffRasterFormat
 from upath import UPath
 
@@ -72,7 +73,7 @@ def convert_era5(window: Window, olmoearth_path: UPath) -> None:
         raster_dir = window.get_raster_dir(LAYER_NAME, band_set.bands, group_idx)
         image = raster_format.decode_raster(
             raster_dir, window.projection, window.bounds
-        )
+        ).get_chw_array()
 
         year_images.append(image)
         year_time_ranges.append(time_range)
@@ -119,7 +120,7 @@ def convert_era5(window: Window, olmoearth_path: UPath) -> None:
         path=year_dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=year_stacked_image,
+        raster=RasterArray(chw_array=year_stacked_image),
         fname=year_dst_fname.name,
     )
     year_metadata_fname = get_modality_temp_meta_fname(
@@ -155,7 +156,7 @@ def convert_era5(window: Window, olmoearth_path: UPath) -> None:
         path=two_week_dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=two_week_image,
+        raster=RasterArray(chw_array=two_week_image),
         fname=two_week_dst_fname.name,
     )
     two_week_metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/era5_10.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/era5_10.py
@@ -12,6 +12,7 @@ import tqdm
 from rslearn.data_sources import Item
 from rslearn.dataset import Dataset, Window
 from rslearn.utils.mp import star_imap_unordered
+from rslearn.utils.raster_array import RasterArray
 from rslearn.utils.raster_format import GeotiffRasterFormat
 from upath import UPath
 
@@ -80,7 +81,7 @@ def convert_era5(window: Window, olmoearth_path: UPath) -> None:
         raster_dir = window.get_raster_dir(LAYER_NAME, band_set.bands, group_idx)
         image = raster_format.decode_raster(
             raster_dir, adjusted_projection, adjusted_bounds
-        )
+        ).get_chw_array()
 
         year_images.append(image)
         year_time_ranges.append(time_range)
@@ -133,7 +134,7 @@ def convert_era5(window: Window, olmoearth_path: UPath) -> None:
         path=year_dst_fname.parent,
         projection=adjusted_projection,
         bounds=adjusted_bounds,
-        array=year_stacked_image,
+        raster=RasterArray(chw_array=year_stacked_image),
         fname=year_dst_fname.name,
     )
     year_metadata_fname = get_modality_temp_meta_fname(
@@ -169,7 +170,7 @@ def convert_era5(window: Window, olmoearth_path: UPath) -> None:
         path=two_week_dst_fname.parent,
         projection=adjusted_projection,
         bounds=adjusted_bounds,
-        array=two_week_image,
+        raster=RasterArray(chw_array=two_week_image),
         fname=two_week_dst_fname.name,
     )
     two_week_metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/eurocrops.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/eurocrops.py
@@ -23,6 +23,7 @@ from rslearn.data_sources import Item
 from rslearn.dataset import Dataset, Window
 from rslearn.utils.geometry import flatten_shape
 from rslearn.utils.mp import star_imap_unordered
+from rslearn.utils.raster_array import RasterArray
 from rslearn.utils.vector_format import GeojsonVectorFormat
 from upath import UPath
 
@@ -193,7 +194,7 @@ def convert_eurocrops(
         path=out_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=array,
+        raster=RasterArray(chw_array=array),
         fname=out_fname.name,
     )
 

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/gse.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/gse.py
@@ -68,7 +68,7 @@ def convert_gse(window: Window, olmoearth_path: UPath) -> None:
         path=dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=image,
+        raster=image,
         fname=dst_fname.name,
     )
     metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/multitemporal_raster.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/multitemporal_raster.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 from rslearn.data_sources import Item
 from rslearn.dataset import Window
 from rslearn.utils.geometry import PixelBounds, Projection
+from rslearn.utils.raster_array import RasterArray
 from upath import UPath
 
 from olmoearth_pretrain.data.constants import BandSet, ModalitySpec, TimeSpan
@@ -157,7 +158,7 @@ def convert_freq(
             )
             image = GEOTIFF_RASTER_FORMAT.decode_raster(
                 raster_dir, adjusted_projection, adjusted_bounds
-            )
+            ).get_chw_array()
             expected_image_size = band_set.get_expected_image_size(
                 window_metadata.get_resolution_factor()
             )
@@ -206,7 +207,7 @@ def convert_freq(
                 path=dst_fname.parent,
                 projection=adjusted_projection,
                 bounds=adjusted_bounds,
-                array=stacked_image,
+                raster=RasterArray(chw_array=stacked_image),
                 fname=dst_fname.name,
             )
 
@@ -288,7 +289,7 @@ def convert_monthly(
 
             image = GEOTIFF_RASTER_FORMAT.decode_raster(
                 raster_dir, adjusted_projection, adjusted_bounds
-            )
+            ).get_chw_array()
             expected_image_size = band_set.get_expected_image_size(
                 modality.tile_resolution_factor
             )
@@ -337,7 +338,7 @@ def convert_monthly(
                 path=dst_fname.parent,
                 projection=adjusted_projection,
                 bounds=adjusted_bounds,
-                array=stacked_image,
+                raster=RasterArray(chw_array=stacked_image),
                 fname=dst_fname.name,
             )
 

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/naip.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/naip.py
@@ -68,7 +68,7 @@ def convert_naip(window: Window, olmoearth_path: UPath) -> None:
         path=dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=image,
+        raster=image,
         fname=dst_fname.name,
     )
     metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/naip_10.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/naip_10.py
@@ -78,7 +78,7 @@ def convert_naip(window: Window, olmoearth_path: UPath) -> None:
         path=dst_fname.parent,
         projection=adjusted_projection,
         bounds=adjusted_bounds,
-        array=image,
+        raster=image,
         fname=dst_fname.name,
     )
     metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/rasterize_openstreetmap.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/rasterize_openstreetmap.py
@@ -13,6 +13,7 @@ import tqdm
 from rasterio.crs import CRS
 from rslearn.utils.geometry import Projection
 from rslearn.utils.mp import star_imap_unordered
+from rslearn.utils.raster_array import RasterArray
 from upath import UPath
 
 from olmoearth_pretrain.data.constants import Modality, TimeSpan
@@ -211,7 +212,7 @@ def rasterize_openstreetmap(olmoearth_path: UPath, in_fname: UPath) -> None:
         path=out_fname.parent,
         projection=Projection(crs, OUTPUT_RESOLUTION, -OUTPUT_RESOLUTION),
         bounds=bounds,
-        array=array,
+        raster=RasterArray(chw_array=array),
         fname=out_fname.name,
     )
 

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/srtm.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/srtm.py
@@ -53,7 +53,7 @@ def convert_srtm(window: Window, olmoearth_path: UPath) -> None:
         path=dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=image,
+        raster=image,
         fname=dst_fname.name,
     )
     metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/worldcereal.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/worldcereal.py
@@ -9,6 +9,7 @@ import numpy as np
 import tqdm
 from rslearn.dataset import Dataset, Window
 from rslearn.utils.mp import star_imap_unordered
+from rslearn.utils.raster_array import RasterArray
 from upath import UPath
 
 from olmoearth_pretrain.data.constants import Modality, TimeSpan
@@ -59,7 +60,7 @@ def convert_worldcereal(window: Window, olmoearth_path: UPath) -> None:
         ndarrays.append(
             GEOTIFF_RASTER_FORMAT.decode_raster(
                 path=window_dir, projection=window.projection, bounds=window.bounds
-            )
+            ).get_chw_array()
         )
 
     assert len(ndarrays) == len(band_set.bands), (
@@ -90,7 +91,7 @@ def convert_worldcereal(window: Window, olmoearth_path: UPath) -> None:
         path=dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=concatenated_arrays,
+        raster=RasterArray(chw_array=concatenated_arrays),
         fname=dst_fname.name,
     )
     metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/worldcover.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/worldcover.py
@@ -53,7 +53,7 @@ def convert_worldcover(window: Window, olmoearth_path: UPath) -> None:
         path=dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=image,
+        raster=image,
         fname=dst_fname.name,
     )
     metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/worldpop.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/worldpop.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 import tqdm
 from rslearn.dataset import Dataset, Window
 from rslearn.utils.mp import star_imap_unordered
+from rslearn.utils.raster_array import RasterArray
 from upath import UPath
 
 from olmoearth_pretrain.data.constants import Modality, TimeSpan
@@ -40,7 +41,7 @@ def convert_worldpop(window: Window, olmoearth_path: UPath) -> None:
     raster_dir = window.get_raster_dir(LAYER_NAME, band_set.bands)
     image = GEOTIFF_RASTER_FORMAT.decode_raster(
         raster_dir, window.projection, window.bounds
-    )
+    ).get_chw_array()
 
     # Clip population count to 0. NODATA is -99999 and includes locations that are
     # mapped as "unsettled" but really that is 0 population.
@@ -62,7 +63,7 @@ def convert_worldpop(window: Window, olmoearth_path: UPath) -> None:
         path=dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=image,
+        raster=RasterArray(chw_array=image),
         fname=dst_fname.name,
     )
     metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/wri_canopy_height_map.py
+++ b/olmoearth_pretrain/dataset_creation/rslearn_to_olmoearth/wri_canopy_height_map.py
@@ -9,6 +9,7 @@ import numpy as np
 import tqdm
 from rslearn.dataset import Dataset, Window
 from rslearn.utils.mp import star_imap_unordered
+from rslearn.utils.raster_array import RasterArray
 from upath import UPath
 
 from olmoearth_pretrain.data.constants import Modality, TimeSpan
@@ -42,7 +43,7 @@ def convert_chm(window: Window, olmoearth_path: UPath) -> None:
     raster_dir = window.get_raster_dir(LAYER_NAME, band_set.bands)
     image = GEOTIFF_RASTER_FORMAT.decode_raster(
         raster_dir, window.projection, window.bounds
-    )
+    ).get_chw_array()
 
     # Skip areas with any nodata (255).
     if image.max() == 255:
@@ -63,7 +64,7 @@ def convert_chm(window: Window, olmoearth_path: UPath) -> None:
         path=dst_fname.parent,
         projection=window.projection,
         bounds=window.bounds,
-        array=image,
+        raster=RasterArray(chw_array=image),
         fname=dst_fname.name,
     )
     metadata_fname = get_modality_temp_meta_fname(

--- a/olmoearth_pretrain/dataset_creation/wri_canopy_height_map/download_wri_canopy_height_map.py
+++ b/olmoearth_pretrain/dataset_creation/wri_canopy_height_map/download_wri_canopy_height_map.py
@@ -54,7 +54,7 @@ def process_chm_tif(bucket: str, key: str, out_fname: str) -> None:
             bounds[3] * y_factor,
         )
 
-        array = GeotiffRasterFormat().decode_raster(
+        raster = GeotiffRasterFormat().decode_raster(
             local_fname.parent,
             wanted_projection,
             wanted_bounds,
@@ -62,12 +62,12 @@ def process_chm_tif(bucket: str, key: str, out_fname: str) -> None:
             fname=local_fname.name,
         )
         out_upath = UPath(out_fname)
-        print(f"writing {array.shape} to {out_upath}")
+        print(f"writing {raster.array.shape} to {out_upath}")
         GeotiffRasterFormat().encode_raster(
             out_upath.parent,
             wanted_projection,
             wanted_bounds,
-            array,
+            raster,
             fname=(out_upath.name + ".tmp"),
         )
         os.rename(out_upath.path + ".tmp", out_upath.path)


### PR DESCRIPTION
WorldCereal consists of overlapping GeoTIFFs, but only one of the GeoTIFFs will be valid (not NODATA) at any given location. Previously, this means that matching may pick the wrong GeoTIFF since it is just arbitrarily selecting one that intersects the window. SINGLE_COMPOSITE will put all intersecting GeoTIFFs into the item group, and FIRST_VALID compositing method (along with setting correct nodata value for the materialization) ensures we handle it correctly.

This seems to increase the number of tiles with non-zero WorldCereal data by about 20%.

The change is a simple config change, but the rslearn_to_olmoearth scripts are also updated to latest version of rslearn (where RasterFormat returns RasterArray instead of numpy array).