### PR TITLE
Remove constraint on max sequence length

### DIFF
--- a/olmoearth_pretrain/nn/flexi_vit.py
+++ b/olmoearth_pretrain/nn/flexi_vit.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
@@ -663,7 +664,7 @@ class CompositeEncodings(nn.Module):
         self,
         embedding_size: int,
         supported_modalities: list[ModalitySpec],
-        max_sequence_length: int,
+        max_sequence_length: int | None = None,
         learnable_channel_embeddings: bool = True,
         random_channel_embeddings: bool = False,
         tokenization_config: TokenizationConfig | None = None,
@@ -676,7 +677,8 @@ class CompositeEncodings(nn.Module):
             embedding_size: Size of token embeddings
             supported_modalities: Which modalities from Modality this model
                 instantiation supports
-            max_sequence_length: Maximum sequence length
+            max_sequence_length: Deprecated, has no effect. Temporal position
+                encodings are now computed on-the-fly.
             learnable_channel_embeddings: Whether to use learnable channel embeddings
             random_channel_embeddings: Initialize channel embeddings randomly (zeros if False)
             tokenization_config: Optional config for custom band groupings
@@ -693,6 +695,13 @@ class CompositeEncodings(nn.Module):
                 f"position_encoding must be one of {PositionEncoding.values()}, "
                 f"got {position_encoding}"
             )
+        if max_sequence_length is not None:
+            warnings.warn(
+                "max_sequence_length is deprecated and has no effect. "
+                "Temporal position encodings are now computed on-the-fly.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.embedding_size = embedding_size
         self.supported_modalities = supported_modalities
         self.supported_modality_names = [
@@ -701,9 +710,6 @@ class CompositeEncodings(nn.Module):
         self.tokenization_config = tokenization_config or TokenizationConfig()
         self.position_encoding = position_encoding
         self.embedding_size = embedding_size
-        self.max_sequence_length = (
-            max_sequence_length  # This max sequence length is a time dim thing
-        )
         # TODO: we need to be able to calculate the size of the param based on what types of embeddings it will get
 
         # we have 4 embeddings types (pos_in_time, pos_in_space, month, channel) so each get

--- a/olmoearth_pretrain/nn/flexi_vit.py
+++ b/olmoearth_pretrain/nn/flexi_vit.py
@@ -709,14 +709,10 @@ class CompositeEncodings(nn.Module):
         # we have 4 embeddings types (pos_in_time, pos_in_space, month, channel) so each get
         # 0.25 of the dimension
         self.embedding_dim_per_embedding_type = int(embedding_size * 0.25)
-        # Position encodings for time dimension initialized to 1D sinusoidal encodings
-        self.pos_embed = nn.Parameter(
-            get_1d_sincos_pos_encoding(
-                torch.arange(max_sequence_length),
-                self.embedding_dim_per_embedding_type,
-            ),
-            requires_grad=False,
-        )
+        # Temporal position encodings are computed on-the-fly via
+        # get_1d_sincos_pos_encoding so that any number of timesteps is supported
+        # without a pre-allocated table.
+        self._register_load_state_dict_pre_hook(self._drop_pos_embed_hook)
         # Month encodings
         month_tab = get_month_encoding_table(self.embedding_dim_per_embedding_type)
         self.month_embed = nn.Embedding.from_pretrained(month_tab, freeze=True)
@@ -757,6 +753,15 @@ class CompositeEncodings(nn.Module):
             if isinstance(m, nn.Linear) and m.bias is not None:
                 # TODO: fix the dtype here
                 nn.init.constant_(m.bias, 0).to(torch.float32)
+
+    @staticmethod
+    def _drop_pos_embed_hook(
+        state_dict: dict, prefix: str, *args: object, **kwargs: object
+    ) -> None:
+        """Drop legacy pos_embed from old checkpoints so strict loading succeeds."""
+        key = prefix + "pos_embed"
+        if key in state_dict:
+            del state_dict[key]
 
     @staticmethod
     def calculate_gsd_ratio(input_res: float, patch_size: int) -> float:
@@ -855,10 +860,13 @@ class CompositeEncodings(nn.Module):
             # Slot-index temporal encoding (additive). Skipped when 3D RoPE
             # handles temporal position rotationally inside attention.
             if not PositionEncoding.is_3d_rope(self.position_encoding):
-                time_embed = repeat(
-                    self.pos_embed[:t], f"t d -> {ein_string}", **ein_dict
+                # Time position encodings (computed on-the-fly for arbitrary t)
+                pos_embed = get_1d_sincos_pos_encoding(
+                    torch.arange(t, device=device),
+                    self.embedding_dim_per_embedding_type,
                 )
-                modality_embed[..., n : n * 2] += time_embed.to(device)
+                time_embed = repeat(pos_embed, f"t d -> {ein_string}", **ein_dict)
+                modality_embed[..., n : n * 2] += time_embed
 
             # Month encodings stay additive in all modes (calendar/seasonal
             # signal is orthogonal to slot-index).

--- a/olmoearth_pretrain/nn/flexi_vit.py
+++ b/olmoearth_pretrain/nn/flexi_vit.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
@@ -620,7 +621,7 @@ class CompositeEncodings(nn.Module):
         self,
         embedding_size: int,
         supported_modalities: list[ModalitySpec],
-        max_sequence_length: int,
+        max_sequence_length: int | None = None,
         learnable_channel_embeddings: bool = True,
         random_channel_embeddings: bool = False,
         tokenization_config: TokenizationConfig | None = None,
@@ -631,12 +632,20 @@ class CompositeEncodings(nn.Module):
             embedding_size: Size of token embeddings
             supported_modalities: Which modalities from Modality this model
                 instantiation supports
-            max_sequence_length: Maximum sequence length
+            max_sequence_length: Deprecated, has no effect. Temporal position
+                encodings are now computed on-the-fly.
             learnable_channel_embeddings: Whether to use learnable channel embeddings
             random_channel_embeddings: Initialize channel embeddings randomly (zeros if False)
             tokenization_config: Optional config for custom band groupings
         """
         super().__init__()
+        if max_sequence_length is not None:
+            warnings.warn(
+                "max_sequence_length is deprecated and has no effect. "
+                "Temporal position encodings are now computed on-the-fly.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.embedding_size = embedding_size
         self.supported_modalities = supported_modalities
         self.supported_modality_names = [
@@ -644,9 +653,6 @@ class CompositeEncodings(nn.Module):
         ]
         self.tokenization_config = tokenization_config or TokenizationConfig()
         self.embedding_size = embedding_size
-        self.max_sequence_length = (
-            max_sequence_length  # This max sequence length is a time dim thing
-        )
         # TODO: we need to be able to calculate the size of the param based on what types of embeddings it will get
 
         # we have 4 embeddings types (pos_in_time, pos_in_space, month, channel) so each get

--- a/olmoearth_pretrain/nn/flexi_vit.py
+++ b/olmoearth_pretrain/nn/flexi_vit.py
@@ -652,14 +652,10 @@ class CompositeEncodings(nn.Module):
         # we have 4 embeddings types (pos_in_time, pos_in_space, month, channel) so each get
         # 0.25 of the dimension
         self.embedding_dim_per_embedding_type = int(embedding_size * 0.25)
-        # Position encodings for time dimension initialized to 1D sinusoidal encodings
-        self.pos_embed = nn.Parameter(
-            get_1d_sincos_pos_encoding(
-                torch.arange(max_sequence_length),
-                self.embedding_dim_per_embedding_type,
-            ),
-            requires_grad=False,
-        )
+        # Temporal position encodings are computed on-the-fly via
+        # get_1d_sincos_pos_encoding so that any number of timesteps is supported
+        # without a pre-allocated table.
+        self._register_load_state_dict_pre_hook(self._drop_pos_embed_hook)
         # Month encodings
         month_tab = get_month_encoding_table(self.embedding_dim_per_embedding_type)
         self.month_embed = nn.Embedding.from_pretrained(month_tab, freeze=True)
@@ -700,6 +696,15 @@ class CompositeEncodings(nn.Module):
             if isinstance(m, nn.Linear) and m.bias is not None:
                 # TODO: fix the dtype here
                 nn.init.constant_(m.bias, 0).to(torch.float32)
+
+    @staticmethod
+    def _drop_pos_embed_hook(
+        state_dict: dict, prefix: str, *args: object, **kwargs: object
+    ) -> None:
+        """Drop legacy pos_embed from old checkpoints so strict loading succeeds."""
+        key = prefix + "pos_embed"
+        if key in state_dict:
+            del state_dict[key]
 
     @staticmethod
     def calculate_gsd_ratio(input_res: float, patch_size: int) -> float:
@@ -795,9 +800,12 @@ class CompositeEncodings(nn.Module):
             modality_embed[..., :n] += channel_embed
 
         if modality.is_multitemporal and use_temporal_encodings:
-            # Time position encodings
-            time_embed = repeat(self.pos_embed[:t], f"t d -> {ein_string}", **ein_dict)
-            modality_embed[..., n : n * 2] += time_embed.to(device)
+            # Time position encodings (computed on-the-fly for arbitrary t)
+            pos_embed = get_1d_sincos_pos_encoding(
+                torch.arange(t, device=device), self.embedding_dim_per_embedding_type
+            )
+            time_embed = repeat(pos_embed, f"t d -> {ein_string}", **ein_dict)
+            modality_embed[..., n : n * 2] += time_embed
 
             # Month encodings
             assert timestamps is not None

--- a/tests/unit/nn/test_flexi_vit.py
+++ b/tests/unit/nn/test_flexi_vit.py
@@ -7,7 +7,10 @@ import torch
 from einops import repeat
 
 from olmoearth_pretrain.data.constants import Modality, ModalitySpec
-from olmoearth_pretrain.nn.encodings import timestamps_to_days
+from olmoearth_pretrain.nn.encodings import (
+    get_1d_sincos_pos_encoding,
+    timestamps_to_days,
+)
 from olmoearth_pretrain.nn.flexi_vit import (
     CompositeEncodings,
     Encoder,
@@ -120,6 +123,56 @@ class TestCompositeEncodings:
             composite_encodings.per_modality_channel_embeddings["sentinel2_l2a"].grad
             is not None
         )
+
+    def test_dynamic_pos_embed_matches_static(self) -> None:
+        """On-the-fly sinusoidal encoding matches a pre-allocated table for overlapping positions."""
+        dim = 48
+        table = get_1d_sincos_pos_encoding(torch.arange(12), dim)
+        for t in [1, 5, 12, 17, 24]:
+            dynamic = get_1d_sincos_pos_encoding(torch.arange(t), dim)
+            overlap = min(t, 12)
+            assert torch.allclose(dynamic[:overlap], table[:overlap], atol=1e-6)
+
+    def test_temporal_encoding_works_beyond_max_sequence_length(
+        self,
+    ) -> None:
+        """Forward pass works when t exceeds the configured max_sequence_length."""
+        ce = CompositeEncodings(
+            embedding_size=16,
+            supported_modalities=[Modality.SENTINEL2_L2A],
+            max_sequence_length=12,
+            random_channel_embeddings=True,
+        )
+        B, H, W, T, C, D = 2, 4, 4, 17, 3, 16
+        tokens = torch.randn(B, H, W, T, C, D)
+        timestamps = torch.zeros(B, T, 3, dtype=torch.long)
+        timestamps[:, :, 1] = torch.arange(T) % 12
+        result = ce._apply_encodings_per_modality(
+            "sentinel2_l2a", tokens, timestamps, patch_size=4, input_res=10
+        )
+        assert result.shape == tokens.shape
+        assert not (result == tokens).all()
+
+    def test_temporal_encoding_values_match_expected(self) -> None:
+        """Temporal position encoding values match get_1d_sincos_pos_encoding directly."""
+        embedding_size = 16
+        n = embedding_size // 4
+        ce = CompositeEncodings(
+            embedding_size=embedding_size,
+            supported_modalities=[Modality.SENTINEL2_L2A],
+            max_sequence_length=12,
+            random_channel_embeddings=True,
+        )
+        B, H, W, T, C, D = 1, 2, 2, 5, 3, embedding_size
+        tokens = torch.zeros(B, H, W, T, C, D)
+        timestamps = torch.zeros(B, T, 3, dtype=torch.long)
+        timestamps[:, :, 1] = torch.arange(T)
+        result = ce._apply_encodings_per_modality(
+            "sentinel2_l2a", tokens, timestamps, patch_size=4, input_res=10
+        )
+        expected_time = get_1d_sincos_pos_encoding(torch.arange(T), n)
+        actual_time = result[0, 0, 0, :, 0, n : 2 * n]
+        assert torch.allclose(actual_time, expected_time, atol=1e-5)
 
 
 # TODO: Add tests for when the inputs are completely masked or different dims or something

--- a/tests/unit/nn/test_flexi_vit.py
+++ b/tests/unit/nn/test_flexi_vit.py
@@ -7,6 +7,7 @@ import torch
 from einops import repeat
 
 from olmoearth_pretrain.data.constants import Modality, ModalitySpec
+from olmoearth_pretrain.nn.encodings import get_1d_sincos_pos_encoding
 from olmoearth_pretrain.nn.flexi_vit import (
     CompositeEncodings,
     Encoder,
@@ -119,6 +120,56 @@ class TestCompositeEncodings:
             composite_encodings.per_modality_channel_embeddings["sentinel2_l2a"].grad
             is not None
         )
+
+    def test_dynamic_pos_embed_matches_static(self) -> None:
+        """On-the-fly sinusoidal encoding matches a pre-allocated table for overlapping positions."""
+        dim = 48
+        table = get_1d_sincos_pos_encoding(torch.arange(12), dim)
+        for t in [1, 5, 12, 17, 24]:
+            dynamic = get_1d_sincos_pos_encoding(torch.arange(t), dim)
+            overlap = min(t, 12)
+            assert torch.allclose(dynamic[:overlap], table[:overlap], atol=1e-6)
+
+    def test_temporal_encoding_works_beyond_max_sequence_length(
+        self,
+    ) -> None:
+        """Forward pass works when t exceeds the configured max_sequence_length."""
+        ce = CompositeEncodings(
+            embedding_size=16,
+            supported_modalities=[Modality.SENTINEL2_L2A],
+            max_sequence_length=12,
+            random_channel_embeddings=True,
+        )
+        B, H, W, T, C, D = 2, 4, 4, 17, 3, 16
+        tokens = torch.randn(B, H, W, T, C, D)
+        timestamps = torch.zeros(B, T, 3, dtype=torch.long)
+        timestamps[:, :, 1] = torch.arange(T) % 12
+        result = ce._apply_encodings_per_modality(
+            "sentinel2_l2a", tokens, timestamps, patch_size=4, input_res=10
+        )
+        assert result.shape == tokens.shape
+        assert not (result == tokens).all()
+
+    def test_temporal_encoding_values_match_expected(self) -> None:
+        """Temporal position encoding values match get_1d_sincos_pos_encoding directly."""
+        embedding_size = 16
+        n = embedding_size // 4
+        ce = CompositeEncodings(
+            embedding_size=embedding_size,
+            supported_modalities=[Modality.SENTINEL2_L2A],
+            max_sequence_length=12,
+            random_channel_embeddings=True,
+        )
+        B, H, W, T, C, D = 1, 2, 2, 5, 3, embedding_size
+        tokens = torch.zeros(B, H, W, T, C, D)
+        timestamps = torch.zeros(B, T, 3, dtype=torch.long)
+        timestamps[:, :, 1] = torch.arange(T)
+        result = ce._apply_encodings_per_modality(
+            "sentinel2_l2a", tokens, timestamps, patch_size=4, input_res=10
+        )
+        expected_time = get_1d_sincos_pos_encoding(torch.arange(T), n)
+        actual_time = result[0, 0, 0, :, 0, n : 2 * n]
+        assert torch.allclose(actual_time, expected_time, atol=1e-5)
 
 
 # TODO: Add tests for when the inputs are completely masked or different dims or something


### PR DESCRIPTION
When rslearn aligns timestamps across multiple modalities, the resulting temporal sequence can be > 12 timesteps. Previously, `CompositeEncodings` pre-allocated a fixed-size position encoding table based on `max_sequence_length` (default 12), which will raise an error when the input had more timesteps than the table size. The fix here computes the temporal position encoding on-the-fly from the actual number of input timesteps, removing the fixed limit. It's also backward compatible since we directly drop the `pos_embed` parameter from old checkpoints.