### PR TITLE
Fix one more edge case for finetuning with preemption

### DIFF
--- a/olmoearth_pretrain/evals/finetune/train.py
+++ b/olmoearth_pretrain/evals/finetune/train.py
@@ -52,6 +52,25 @@ def _get_wandb_logger(trainer: Trainer) -> Any | None:
     return None
 
 
+def _save_best_and_cleanup(
+    best_state: dict[str, torch.Tensor],
+    best_checkpoint_path: str | None,
+    resume_checkpoint_path: str | None,
+) -> None:
+    """Save the best model checkpoint and remove the resume checkpoint."""
+    if best_checkpoint_path is not None:
+        dir_path = os.path.dirname(best_checkpoint_path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+        torch.save(best_state, best_checkpoint_path)
+        logger.info(f"Saved best checkpoint to {best_checkpoint_path}")
+    else:
+        logger.info("No best checkpoint path provided, skipping saving best checkpoint")
+    if resume_checkpoint_path and os.path.exists(resume_checkpoint_path):
+        os.remove(resume_checkpoint_path)
+        logger.info(f"Removed resume checkpoint {resume_checkpoint_path}")
+
+
 def compute_eval_metrics(
     ft: nn.Module,
     task_config: EvalDatasetConfig,
@@ -199,7 +218,6 @@ def run_finetune_eval(
 
     best_state = snapshot_state_dict(ft)
     best_val_metric = float("-inf")
-    best_val_result: EvalResult | None = None
     start_epoch = 0
 
     # Resume from checkpoint if it exists
@@ -218,6 +236,27 @@ def run_finetune_eval(
             f"Resumed from epoch {start_epoch}, best_val_metric={best_val_metric:.4f}, "
             f"backbone_unfrozen={backbone_unfrozen}"
         )
+
+        # All epochs already completed in a previous run — save best, clean up, evaluate.
+        if start_epoch >= epochs:
+            logger.info(
+                "All epochs already completed before preemption. "
+                "Saving best checkpoint and evaluating."
+            )
+            ft.load_state_dict(best_state)
+            _save_best_and_cleanup(
+                best_state, best_checkpoint_path, resume_checkpoint_path
+            )
+            return compute_eval_metrics(
+                ft,
+                task_config,
+                val_loader,
+                test_loader,
+                device,
+                patch_size,
+                primary_metric=primary_metric,
+                primary_metric_class=primary_metric_class,
+            )
 
     ft.train()
     wandb_logger = _get_wandb_logger(trainer)
@@ -312,7 +351,6 @@ def run_finetune_eval(
         # This assumes that the validation metric is the higher the better.
         if val_result.primary > best_val_metric:
             best_val_metric = val_result.primary
-            best_val_result = val_result
             best_state = snapshot_state_dict(ft)
             logger.info(
                 f"New best validation metric {best_val_metric:.4f} at epoch {epoch + 1}"
@@ -334,44 +372,14 @@ def run_finetune_eval(
         ft.train()
 
     ft.load_state_dict(best_state)
-    if best_checkpoint_path is not None:
-        dir_path = os.path.dirname(best_checkpoint_path)
-        if dir_path:
-            os.makedirs(dir_path, exist_ok=True)
-        torch.save(best_state, best_checkpoint_path)
-        logger.info(f"Saved best checkpoint to {best_checkpoint_path}")
-    else:
-        logger.info("No best checkpoint path provided, skipping saving best checkpoint")
-
-    # Clean up resume checkpoint after successful completion
-    if resume_checkpoint_path and os.path.exists(resume_checkpoint_path):
-        os.remove(resume_checkpoint_path)
-        logger.info(f"Removed resume checkpoint {resume_checkpoint_path}")
-
-    # Evaluate test set
-    test_result: EvalResult | None = None
-    if test_loader is not None:
-        if task_config.task_type == TaskType.CLASSIFICATION:
-            test_result = eval_cls(
-                ft,
-                test_loader,
-                device,
-                task_config.is_multilabel,
-                primary_metric=primary_metric,
-                primary_metric_class=primary_metric_class,
-            )
-        else:
-            test_result = eval_seg(
-                ft,
-                test_loader,
-                device,
-                task_config.num_classes,
-                patch_size,
-                primary_metric=primary_metric,
-                primary_metric_class=primary_metric_class,
-            )
-
-    return EvalTaskResult(
-        val_result=best_val_result,
-        test_result=test_result,
+    _save_best_and_cleanup(best_state, best_checkpoint_path, resume_checkpoint_path)
+    return compute_eval_metrics(
+        ft,
+        task_config,
+        val_loader,
+        test_loader,
+        device,
+        patch_size,
+        primary_metric=primary_metric,
+        primary_metric_class=primary_metric_class,
     )

--- a/olmoearth_pretrain/internal/all_evals.py
+++ b/olmoearth_pretrain/internal/all_evals.py
@@ -476,6 +476,7 @@ FT_EVAL_TASKS = {
         epochs=50,
         primary_metric=EvalMetric.MIOU,
     ),
+    # Cashew plant requires a larger patch size; 16 performed best.
     "m_cashew_plant": DownstreamTaskConfig(
         dataset="m-cashew-plant",
         ft_batch_size=4,
@@ -484,6 +485,7 @@ FT_EVAL_TASKS = {
         norm_stats_from_pretrained=False,
         norm_method=NormMethod.NORM_NO_CLIP_2_STD,
         epochs=50,
+        patch_size=16,
         primary_metric=EvalMetric.MIOU,
     ),
     "m_forestnet": DownstreamTaskConfig(

--- a/olmoearth_pretrain/train/callbacks/evaluator_callback.py
+++ b/olmoearth_pretrain/train/callbacks/evaluator_callback.py
@@ -694,13 +694,9 @@ class DownstreamEvaluatorCallback(Callback):
                 )
                 wandb_callback.wandb.log({f"{evaluator.evaluation_name}_step": 0})
 
-        # Check if results are valid
-        val_valid = val_result is not None and val_result.primary >= 0
+        # Log test results and bootstrap stats independently of val validity
         test_valid = test_result is not None and test_result.primary >= 0
-
-        # Only logging valid results to wandb
-        if wandb_callback.enabled and val_valid and test_valid:
-            # Log bootstrap statistics if available
+        if wandb_callback.enabled and test_valid:
             if bootstrap_stats:
                 wandb_callback.wandb.log(
                     {


### PR DESCRIPTION
One more edge case if the job gets preempted: 

When a job is preempted after all finetune epochs complete but before the best checkpoint is saved, the resumed run skips the training loop (since all epochs are done), leaving val_result as None, which blocks both val and test metrics from being logged to wandb.

Also, removed some redundant code. 