### PR TITLE
fix geo evals primary metric

### DIFF
--- a/olmoearth_pretrain/internal/all_evals.py
+++ b/olmoearth_pretrain/internal/all_evals.py
@@ -323,7 +323,6 @@ EVAL_TASKS = {
         input_modalities=[Modality.SENTINEL2_L2A.name],
         epochs=50,
         eval_mode=EvalMode.LINEAR_PROBE,
-        primary_metric=EvalMetric.ACCURACY,
     ),
     "forest_loss_driver": DownstreamTaskConfig(
         dataset="forest_loss_driver",

--- a/olmoearth_pretrain/internal/all_evals.py
+++ b/olmoearth_pretrain/internal/all_evals.py
@@ -323,6 +323,7 @@ EVAL_TASKS = {
         input_modalities=[Modality.SENTINEL2_L2A.name],
         epochs=50,
         eval_mode=EvalMode.LINEAR_PROBE,
+        primary_metric=EvalMetric.OVERALL_ACC,
     ),
     "forest_loss_driver": DownstreamTaskConfig(
         dataset="forest_loss_driver",


### PR DESCRIPTION
otherwise the geo evals fail with 

```
2026-04-10T18:44:28.293Z ValueError: primary_metric 'accuracy' not found in computed metrics: ['miou', 'overall_acc', 'macro_acc', 'macro_f1', 'micro_f1', 'f1_class_0', 'f1_class_1', 'f1_class_2', 'f1_class_3', 'f1_class_4', 'f1_class_5', 'f1_class_6', 'f1_class_7', 'f1_class_8', 'f1_class_9', 'f1_class_10', 'f1_class_11', 'f1_class_12', 'f1_class_13', 'f1_class_14', 'f1_class_15', 'f1_class_16', 'f1_class_17', 'f1_class_18', 'f1_class_19', 'f1_class_20', 'f1_class_21', 'f1_class_22', 'f1_class_23', 'f1_class_24', 'f1_class_25', 'f1_class_26', 'f1_class_27', 'f1_class_28', 'f1_class_29', 'f1_class_30', 'f1_class_31', 'f1_class_32', 'f1_class_33', 'f1_class_34', 'f1_class_35', 'f1_class_36', 'f1_class_37', 'f1_class_38', 'f1_class_39', 'f1_class_40', 'f1_class_41', 'f1_class_42', 'f1_class_43', 'f1_class_44', 'f1_class_45', 'f1_class_46', 'f1_class_47', 'f1_class_48', 'f1_class_49', 'f1_class_50', 'f1_class_51', 'f1_class_52', 'f1_class_53', 'f1_class_54', 'f1_class_55', 'f1_class_56', 'f1_class_57', 'f1_class_58', 'f1_class_59', 'f1_class_60', 'f1_class_61', 'f1_class_62', 'f1_class_63', 'f1_class_64', 'f1_class_65', 'f1_class_66', 'f1_class_67', 'f1_class_68', 'f1_class_69', 'f1_class_70', 'f1_class_71', 'f1_class_72', 'f1_class_73', 'f1_class_74', 'f1_class_75', 'f1_class_76', 'f1_class_77', 'f1_class_78', 'f1_class_79', 'f1_class_80', 'f1_class_81', 'f1_class_82', 'f1_class_83', 'f1_class_84', 'f1_class_85', 'f1_class_86', 'f1_class_87', 'f1_class_88', 'f1_class_89', 'f1_class_90', 'f1_class_91', 'f1_class_92', 'f1_class_93', 'f1_class_94', 'f1_class_95', 'f1_class_96', 'f1_class_97', 'f1_class_98', 'f1_class_99', 'f1_class_100', 'f1_class_101', 'f1_class_102', 'f1_class_103', 'f1_class_104', 'f1_class_105', 'f1_class_106', 'f1_class_107', 'f1_class_108', 'f1_class_109', 'f1_class_110', 'f1_class_111']
```