### PR TITLE
Fix device mismatch in random_time_with_decode masking

### DIFF
--- a/olmoearth_pretrain/train/masking.py
+++ b/olmoearth_pretrain/train/masking.py
@@ -1917,7 +1917,9 @@ class RandomTimeWithDecodeMaskingStrategy(MaskingStrategy):
                 else:
                     use_random_masking = False
                     not_missing_t = torch.argwhere(missing_per_time)[:, 0]
-                    not_missing_t = not_missing_t[torch.randperm(len(not_missing_t))]
+                    not_missing_t = not_missing_t[
+                        torch.randperm(len(not_missing_t), device=not_missing_t.device)
+                    ]
                     num_encode = math.ceil(len(not_missing_t) * self.encode_ratio)
                     encode_timestamps = not_missing_t[:num_encode]
                     decode_timestamps = not_missing_t[num_encode:]


### PR DESCRIPTION
## Summary
- `torch.randperm` at `masking.py:1920` was missing `device=` arg, causing it to default to CUDA while the indexed tensor was on CPU
- Every other `randperm` call in the file already passes `device=` correctly — this was the only one missed
- Crashes any experiment using `random_time_with_decode` masking strategy

## Test plan
- [x] Verified fix locally: 100-step training run completed successfully with `random_time_with_decode` masking + `static_temporal` encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)