### PR TITLE
Fix worlcover config

### DIFF
--- a/data/rslearn_dataset_configs/config_worldcover.json
+++ b/data/rslearn_dataset_configs/config_worldcover.json
@@ -12,7 +12,7 @@
       "data_source": {
         "class_path": "rslearn.data_sources.worldcover.WorldCover",
         "init_args": {
-          "worldcover_dir": "source_data/worldcover/"
+          "metadata_cache_dir": "cache/worldcover"
         }
       },
       "resampling_method": "nearest",


### PR DESCRIPTION
`worldcover_dir` results in this error:
```
error: Parser key "data_source":
  Problem with given class_path 'rslearn.data_sources.worldcover.WorldCover':
    Option 'worldcover_dir' is not accepted
```

Seems like `rslearn.data_sources.worldcover.WorldCover` was changed to read Cloud-Optimized GeoTIFFs from the public bucket s3://esa-worldcover.