### PR TITLE
add skip task names arg to finetune sweep script

### DIFF
--- a/olmoearth_pretrain/internal/full_eval_sweep_finetune.py
+++ b/olmoearth_pretrain/internal/full_eval_sweep_finetune.py
@@ -31,6 +31,7 @@ Each FT eval task's normalization is defined in all_evals.py.
 """
 
 import argparse
+import json
 import os
 import subprocess  # nosec
 import uuid
@@ -409,6 +410,18 @@ def build_commands(
                 seed_args=seed_args,
             )
         )
+
+    if args.task_skip_names:
+        skip_names = [name.strip() for name in args.task_skip_names.split(",")]
+        tasks_to_run = [task for task in FT_EVAL_TASKS.keys() if task not in skip_names]
+        tasks_to_run_arg = f" --trainer.callbacks.downstream_evaluator.tasks_to_run='{json.dumps(tasks_to_run)}'"
+        commands_new = []
+        for cmd in commands:
+            logger.info(f"Adding tasks_to_run filter to {cmd}")
+            cmd += tasks_to_run_arg
+            commands_new.append(cmd)
+        commands = commands_new
+
     return commands
 
 
@@ -470,6 +483,16 @@ def main() -> None:
         type=int,
         default=None,
         help="Base random seed applied to every finetune task (optional).",
+    )
+    parser.add_argument(
+        "--task-skip-names",
+        type=str,
+        required=False,
+        help=(
+            "Comma-separated FT eval task keys to skip (intersected with FT_EVAL_TASKS; "
+            "other names are ignored). If no FT tasks would remain, all FT tasks are run "
+            "with a warning."
+        ),
     )
 
     args, extra_cli = parser.parse_known_args()


### PR DESCRIPTION
For convenience, copy code from the full_eval_sweep.py that allows you to skip FT eval tasks.