### PR TITLE
Cap AnySat patch_size at input image size

### DIFF
--- a/olmoearth_pretrain/evals/models/anysat/anysat.py
+++ b/olmoearth_pretrain/evals/models/anysat/anysat.py
@@ -227,6 +227,12 @@ class AnySat(nn.Module):
         patch_size_meters = (
             max(self.patch_size, self._calculate_patch_size(hs[0])) * self.resolution
         )
+        # Cap at the input image size. For single-pixel time-series inputs
+        # (e.g. breizhcrops, cropharvest, awf, nandi at h=w=1), AnySat's LTAE
+        # encoder calls `x.unfold(spatial_dim, scale, scale)` where
+        # scale=patch_size_meters//resolution; with scale > h that unfold
+        # raises "maximum size for tensor at dimension 2 is 1 but size is N".
+        patch_size_meters = min(patch_size_meters, hs[0] * self.resolution)
         logger.info(f"Using patch size {patch_size_meters} for AnySat")
 
         # from the README (https://github.com/gastruc/AnySat/blob/main/README.md):


### PR DESCRIPTION
## Summary

The AnySat eval wrapper crashes with
`RuntimeError: maximum size for tensor at dimension 2 is 1 but size is N`
on any task with single-pixel spatial inputs (h=w=1): `breizhcrops`, the
`cropharvest_*` variants, and the time-series classification flavours of
`awf`/`nandi`.

The wrapper computes

```python
patch_size_meters = max(self.patch_size, _calculate_patch_size(h)) * self.resolution
```

which is unconditionally floored by `self.patch_size` (default 4) — so
for h=1 inputs we still produce `patch_size_meters = 40`. AnySat's LTAE
encoder then calls `x.unfold(spatial_dim, scale, scale)` where
`scale = patch_size_meters // resolution`, and that unfold raises when
`scale > h`.

Add a final clamp so we never ask AnySat to patch larger than the input
image. No behaviour change for the h ≥ self.patch_size case.

## Test plan

- [x] Compiles
- [ ] Re-run the embedding-dump sweep that previously failed on
      `breizhcrops`, `cropharvest_*`, `awf_*`, `nandi_*` for AnySat — these
      tasks should now complete without the LTAE unfold crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)