### PR TITLE
Mitigate memory leak in pre-training runs

### DIFF
--- a/olmoearth_pretrain/evals/datasets/geobench_dataset.py
+++ b/olmoearth_pretrain/evals/datasets/geobench_dataset.py
@@ -7,7 +7,7 @@ from types import MethodType
 
 import matplotlib.pyplot as plt
 import numpy as np
-import torch.multiprocessing
+import torch
 from einops import repeat
 from geobench.dataset import Stats
 from geobench.task import load_task_specs
@@ -25,8 +25,6 @@ from .constants import (
     EVAL_TO_OLMOEARTH_S2_BANDS,
 )
 from .normalize import impute_normalization_stats, normalize_bands
-
-torch.multiprocessing.set_sharing_strategy("file_system")
 
 logger = logging.getLogger(__name__)
 

--- a/olmoearth_pretrain/evals/datasets/mados_dataset.py
+++ b/olmoearth_pretrain/evals/datasets/mados_dataset.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import numpy as np
 import torch
-import torch.multiprocessing
 import torch.nn.functional as F
 from einops import repeat
 from PIL import Image
@@ -19,9 +18,6 @@ from olmoearth_pretrain.train.masking import MaskedOlmoEarthSample
 from .constants import EVAL_S2_BAND_NAMES, EVAL_TO_OLMOEARTH_S2_BANDS
 from .normalize import normalize_bands
 from .utils import load_min_max_stats
-
-torch.multiprocessing.set_sharing_strategy("file_system")
-
 
 BAND_STATS = {
     "01 - Coastal aerosol": {

--- a/olmoearth_pretrain/evals/datasets/pastis_dataset.py
+++ b/olmoearth_pretrain/evals/datasets/pastis_dataset.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import einops
 import numpy as np
 import torch
-import torch.multiprocessing
 from torch.utils.data import Dataset
 
 from olmoearth_pretrain.data.constants import Modality
@@ -23,9 +22,6 @@ from olmoearth_pretrain.evals.datasets.utils import load_min_max_stats
 from olmoearth_pretrain.train.masking import MaskedOlmoEarthSample
 
 logger = logging.getLogger(__name__)
-
-# TODO: Move this into a worker init function and see if this has to do with the eval memory leak on long runs
-torch.multiprocessing.set_sharing_strategy("file_system")
 
 
 S2_BAND_STATS = {


### PR DESCRIPTION
The dataloader workers have some memory leak, maybe a leak internal to the h5py library, maybe something else.

We already use non-persistent workers (we actually pass `persistent_workers=True`, but we reset the dataloader each epoch which is effectively the same as having `persistent_workers=False`), but `torch.multiprocessing.set_sharing_strategy("file_system")` causes accumulation of `torch_shm_manager` processes -- they are supposed to exit when the corresponding dataloader process exits, but they don't, maybe due to the memory leak.

So removing this fixes the problem. I considered moving it to run when the evaluation dataloader processes start, but I wasn't able to reproduce file descriptor limit issues, and also it might still cause accumulation of the `torch_shm_manager` processes anyway.