### PR TITLE
Mapbiomas eval (Brazil)

### DIFF
--- a/olmoearth_pretrain/evals/constants.py
+++ b/olmoearth_pretrain/evals/constants.py
@@ -1,6 +1,10 @@
 """Constants shared across eval modules."""
 
+import logging
+
 from olmoearth_pretrain.data.constants import Modality, ModalitySpec
+
+logger = logging.getLogger(__name__)
 
 # rslearn layer name -> OlmoEarth ModalitySpec (single source of truth)
 RSLEARN_TO_OLMOEARTH: dict[str, ModalitySpec] = {
@@ -11,3 +15,40 @@ RSLEARN_TO_OLMOEARTH: dict[str, ModalitySpec] = {
     "sentinel1_descending": Modality.SENTINEL1,
     "landsat": Modality.LANDSAT,
 }
+
+
+def resolve_rslearn_layer_name(layer_name: str) -> str | None:
+    """Resolve an rslearn layer name to a key in RSLEARN_TO_OLMOEARTH.
+
+    Tries, in order:
+      1. Direct lookup (e.g. ``"sentinel2_l2a"``).
+      2. Prefix stripping: ``"pre_"`` / ``"post_"`` (e.g. ``"pre_sentinel2"``).
+      3. Progressive suffix stripping: (e.g. ``"pre_sentinel2_feb"``)
+      4. Prefix stripping *then* suffix stripping
+
+    Returns:
+        The matched key in ``RSLEARN_TO_OLMOEARTH``, or ``None``.
+    """
+    if layer_name in RSLEARN_TO_OLMOEARTH:
+        return layer_name
+
+    # Build candidates: original + prefix-stripped variants
+    candidates = [layer_name]
+    for prefix in ("pre_", "post_"):
+        if layer_name.startswith(prefix):
+            candidates.append(layer_name[len(prefix) :])
+
+    for candidate in candidates:
+        current = candidate
+        while "_" in current:
+            current = current.rsplit("_", 1)[0]
+            if current in RSLEARN_TO_OLMOEARTH:
+                logger.info(
+                    "Resolved rslearn layer %r -> %r (modality: %s)",
+                    layer_name,
+                    current,
+                    RSLEARN_TO_OLMOEARTH[current].name,
+                )
+                return current
+
+    return None

--- a/olmoearth_pretrain/evals/datasets/rslearn_dataset.py
+++ b/olmoearth_pretrain/evals/datasets/rslearn_dataset.py
@@ -22,7 +22,10 @@ from torch.utils.data import Dataset, IterableDataset, Subset
 from olmoearth_pretrain.data.constants import YEAR_NUM_TIMESTEPS, Modality
 from olmoearth_pretrain.data.normalize import Normalizer, Strategy
 from olmoearth_pretrain.data.utils import convert_to_db
-from olmoearth_pretrain.evals.constants import RSLEARN_TO_OLMOEARTH
+from olmoearth_pretrain.evals.constants import (
+    RSLEARN_TO_OLMOEARTH,
+    resolve_rslearn_layer_name,
+)
 from olmoearth_pretrain.evals.datasets.normalize import NormMethod
 from olmoearth_pretrain.evals.datasets.rslearn_builder import (
     build_model_dataset,
@@ -251,16 +254,8 @@ class RslearnToOlmoEarthDataset(Dataset):
             layers = get_modality_layers(model_config)
             input_modalities = []
             for layer in layers:
-                resolved = layer
-                if layer not in RSLEARN_TO_OLMOEARTH:
-                    for prefix in ("pre_", "post_"):
-                        if (
-                            layer.startswith(prefix)
-                            and layer[len(prefix) :] in RSLEARN_TO_OLMOEARTH
-                        ):
-                            resolved = layer[len(prefix) :]
-                            break
-                if resolved in RSLEARN_TO_OLMOEARTH:
+                resolved = resolve_rslearn_layer_name(layer)
+                if resolved is not None:
                     input_modalities.append(RSLEARN_TO_OLMOEARTH[resolved].name)
                 else:
                     input_modalities.append(layer)

--- a/olmoearth_pretrain/evals/studio_ingest/band_stats.py
+++ b/olmoearth_pretrain/evals/studio_ingest/band_stats.py
@@ -33,7 +33,10 @@ from tqdm import tqdm
 
 from olmoearth_pretrain.data.constants import Modality as DataModality
 from olmoearth_pretrain.data.utils import convert_to_db
-from olmoearth_pretrain.evals.constants import RSLEARN_TO_OLMOEARTH
+from olmoearth_pretrain.evals.constants import (
+    RSLEARN_TO_OLMOEARTH,
+    resolve_rslearn_layer_name,
+)
 from olmoearth_pretrain.evals.datasets.rslearn_builder import (
     build_model_dataset,
     get_modality_layers,
@@ -54,22 +57,6 @@ def _collate_inputs_only(batch: list) -> list:
     return batch
 
 
-def _resolve_layer_name(layer: str) -> str | None:
-    """Resolve an rslearn layer name to a key in RSLEARN_TO_OLMOEARTH.
-
-    Also handles layer names prefixed with "pre_" or "post_" to make
-    compatible with older datasets that use these prefixed layer names.
-    """
-    if layer in RSLEARN_TO_OLMOEARTH:
-        return layer
-    for prefix in ("pre_", "post_"):
-        if layer.startswith(prefix):
-            stripped = layer[len(prefix) :]
-            if stripped in RSLEARN_TO_OLMOEARTH:
-                return stripped
-    return None
-
-
 def _get_bands_by_modality(
     model_config: dict[str, Any],
 ) -> dict[str, list[str]]:
@@ -85,7 +72,7 @@ def _get_bands_by_modality(
     modality_layers = get_modality_layers(model_config)
 
     for layer in modality_layers:
-        resolved = _resolve_layer_name(layer)
+        resolved = resolve_rslearn_layer_name(layer)
         if resolved is not None:
             modality = RSLEARN_TO_OLMOEARTH[resolved]
             bands_by_modality[modality.name] = modality.band_order

--- a/olmoearth_pretrain/evals/studio_ingest/ingest.py
+++ b/olmoearth_pretrain/evals/studio_ingest/ingest.py
@@ -1104,10 +1104,12 @@ def ingest_dataset(config: IngestConfig) -> EvalDatasetEntry:
     logger.info("[Step 0b] Model config loaded and validated successfully")
 
     # Step 0c: Extract modalities from dataset config
+    # Multiple rslearn layers can map to the same OlmoEarth modality (e.g.
+    # sentinel2_l2a_feb, _may, _aug, _nov all resolve to sentinel2_l2a).
+    # We deduplicate and aggregate max_matches across temporal layers.
     logger.info("[Step 0c] Extracting modalities from dataset config...")
-    modalities = []
+    modality_max_timesteps: dict[str, int] = {}
     modality_layer_names = []
-    max_timesteps_modalities = []
     for layer_name, layer_config in dataset_config.layers.items():
         if layer_config.data_source is None:
             continue
@@ -1118,12 +1120,16 @@ def ingest_dataset(config: IngestConfig) -> EvalDatasetEntry:
                 f"  Skipping layer {layer_name!r}: no OlmoEarth modality mapping"
             )
             continue
-        modalities.append(olmoearth_modality.name)
         modality_layer_names.append(layer_name)
         query_config = layer_config.data_source.query_config
-        max_timesteps_modalities.append(query_config.max_matches)
+        mod_name = olmoearth_modality.name
+        prev = modality_max_timesteps.get(mod_name, 0)
+        modality_max_timesteps[mod_name] = max(prev, query_config.max_matches)
 
-    num_timesteps = max(max_timesteps_modalities) if max_timesteps_modalities else 1
+    modalities = list(modality_max_timesteps.keys())
+    num_timesteps = (
+        max(modality_max_timesteps.values()) if modality_max_timesteps else 1
+    )
     timeseries = num_timesteps > 1
     logger.info(
         f"[Step 0c] Modalities: {modalities}, timeseries: {timeseries}, num_timesteps: {num_timesteps}"

--- a/olmoearth_pretrain/evals/studio_ingest/registry.json
+++ b/olmoearth_pretrain/evals/studio_ingest/registry.json
@@ -777,6 +777,258 @@
       "weka_path": "/weka/dfive-default/olmoearth/eval_datasets/lfmc_woody_3k",
       "window_size": 32
     },
+    "mapbiomas_3k_dense": {
+      "classes": [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18",
+        "19",
+        "20",
+        "21",
+        "22",
+        "23",
+        "24",
+        "25",
+        "26",
+        "27"
+      ],
+      "imputes": [],
+      "is_multilabel": false,
+      "modalities": [
+        "sentinel2_l2a"
+      ],
+      "name": "mapbiomas_3k_dense",
+      "norm_stats": {
+        "sentinel2_l2a": {
+          "B01": {
+            "max": 21188.0,
+            "mean": 1178.3196671393252,
+            "min": 0.0,
+            "std": 2160.96518630583
+          },
+          "B02": {
+            "max": 21496.0,
+            "mean": 1181.8570192441705,
+            "min": 0.0,
+            "std": 1997.010247697416
+          },
+          "B03": {
+            "max": 18600.0,
+            "mean": 1363.7875293896645,
+            "min": 0.0,
+            "std": 1828.2351101317854
+          },
+          "B04": {
+            "max": 16848.0,
+            "mean": 1357.5472572928786,
+            "min": 0.0,
+            "std": 1780.607937768556
+          },
+          "B05": {
+            "max": 17859.0,
+            "mean": 1830.1684852279063,
+            "min": 0.0,
+            "std": 1816.8727974828155
+          },
+          "B06": {
+            "max": 16111.0,
+            "mean": 2704.475580521621,
+            "min": 0.0,
+            "std": 1592.2282619377193
+          },
+          "B07": {
+            "max": 15905.0,
+            "mean": 3036.2434573531727,
+            "min": 0.0,
+            "std": 1563.45183492202
+          },
+          "B08": {
+            "max": 15792.0,
+            "mean": 3053.6191605463446,
+            "min": 0.0,
+            "std": 1545.5169652313946
+          },
+          "B09": {
+            "max": 18687.0,
+            "mean": 3930.6092828921855,
+            "min": 0.0,
+            "std": 3127.18428658663
+          },
+          "B11": {
+            "max": 15178.0,
+            "mean": 2602.670436724355,
+            "min": 0.0,
+            "std": 1284.2801212740032
+          },
+          "B12": {
+            "max": 15115.0,
+            "mean": 1771.4227302543873,
+            "min": 0.0,
+            "std": 1181.02085642642
+          },
+          "B8A": {
+            "max": 15708.0,
+            "mean": 3248.300499586424,
+            "min": 0.0,
+            "std": 1526.5195466386965
+          }
+        }
+      },
+      "num_classes": 28,
+      "num_timesteps": 1,
+      "source_path": "/weka/dfive-default/rslearn-eai/datasets/mapbiomas_3k",
+      "split_stats": {
+        "test": {
+          "count": 500
+        },
+        "train": {
+          "count": 2989
+        },
+        "val": {
+          "count": 500
+        }
+      },
+      "split_tag_key": "eval_split",
+      "task_type": "segmentation",
+      "timeseries": false,
+      "use_pretrain_norm": true,
+      "weka_path": "/weka/dfive-default/olmoearth/eval_datasets/mapbiomas_3k_dense",
+      "window_size": 48
+    },
+    "mapbiomas_3k_sparse": {
+      "classes": [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11"
+      ],
+      "imputes": [],
+      "is_multilabel": false,
+      "modalities": [
+        "sentinel2_l2a"
+      ],
+      "name": "mapbiomas_3k_sparse",
+      "norm_stats": {
+        "sentinel2_l2a": {
+          "B01": {
+            "max": 23216.0,
+            "mean": 1184.1198050754665,
+            "min": 0.0,
+            "std": 2166.501115807584
+          },
+          "B02": {
+            "max": 21624.0,
+            "mean": 1181.418003064162,
+            "min": 0.0,
+            "std": 2002.0262906741718
+          },
+          "B03": {
+            "max": 18360.0,
+            "mean": 1351.3649118296064,
+            "min": 0.0,
+            "std": 1836.2411064218654
+          },
+          "B04": {
+            "max": 16960.0,
+            "mean": 1332.5680677046237,
+            "min": 0.0,
+            "std": 1788.8065115143809
+          },
+          "B05": {
+            "max": 17479.0,
+            "mean": 1782.143956990135,
+            "min": 0.0,
+            "std": 1830.577027757731
+          },
+          "B06": {
+            "max": 15993.0,
+            "mean": 2633.662619566306,
+            "min": 0.0,
+            "std": 1640.729997622537
+          },
+          "B07": {
+            "max": 15865.0,
+            "mean": 2958.285876074559,
+            "min": 0.0,
+            "std": 1627.887758234076
+          },
+          "B08": {
+            "max": 15936.0,
+            "mean": 2973.287069844158,
+            "min": 0.0,
+            "std": 1613.211021292013
+          },
+          "B09": {
+            "max": 18747.0,
+            "mean": 3862.6820176170763,
+            "min": 0.0,
+            "std": 3186.128428671241
+          },
+          "B11": {
+            "max": 15175.0,
+            "mean": 2491.187661987575,
+            "min": 0.0,
+            "std": 1325.1035753412996
+          },
+          "B12": {
+            "max": 15106.0,
+            "mean": 1693.995320676663,
+            "min": 0.0,
+            "std": 1193.5547111794458
+          },
+          "B8A": {
+            "max": 15690.0,
+            "mean": 3160.006016570958,
+            "min": 0.0,
+            "std": 1605.747721831359
+          }
+        }
+      },
+      "num_classes": 12,
+      "num_timesteps": 1,
+      "source_path": "/weka/dfive-default/rslearn-eai/datasets/mapbiomas_3k",
+      "split_stats": {
+        "test": {
+          "count": 487
+        },
+        "train": {
+          "count": 2921
+        },
+        "val": {
+          "count": 486
+        }
+      },
+      "split_tag_key": "eval_split",
+      "task_type": "segmentation",
+      "timeseries": false,
+      "use_pretrain_norm": true,
+      "weka_path": "/weka/dfive-default/olmoearth/eval_datasets/mapbiomas_3k_sparse",
+      "window_size": 48
+    },
     "nandi_crop_map": {
       "classes": [
         "0",
@@ -1358,6 +1610,6 @@
       "window_size": 16
     }
   },
-  "updated_at": "2026-05-26T21:58:17.996682",
+  "updated_at": "2026-06-08T22:53:36.400354",
   "version": "1.0"
 }

--- a/olmoearth_pretrain/evals/studio_ingest/schema.py
+++ b/olmoearth_pretrain/evals/studio_ingest/schema.py
@@ -35,7 +35,10 @@ if TYPE_CHECKING:
     from olmoearth_pretrain.evals.datasets.configs import EvalDatasetConfig
 
 from olmoearth_pretrain.data.constants import ModalitySpec
-from olmoearth_pretrain.evals.constants import RSLEARN_TO_OLMOEARTH
+from olmoearth_pretrain.evals.constants import (
+    RSLEARN_TO_OLMOEARTH,
+    resolve_rslearn_layer_name,
+)
 from olmoearth_pretrain.evals.task_types import TaskType
 
 # =============================================================================
@@ -101,18 +104,12 @@ def instantiate_from_config(config: dict) -> Any:
 def rslearn_to_olmoearth(layer_name: str) -> ModalitySpec:
     """Map an rslearn layer name to an OlmoEarth ModalitySpec.
 
-    Uses RSLEARN_TO_OLMOEARTH from rslearn_dataset as the single source of truth.
-    Also handles layer names prefixed with "pre_" or "post_" (e.g.
-    "pre_sentinel2" -> Modality.SENTINEL2_L2A).
+    Uses :func:`resolve_rslearn_layer_name` for flexible matching
+    (direct, prefix-stripped, and suffix-stripped layer names).
     """
-    if layer_name in RSLEARN_TO_OLMOEARTH:
-        return RSLEARN_TO_OLMOEARTH[layer_name]
-
-    for prefix in ("pre_", "post_"):
-        if layer_name.startswith(prefix):
-            stripped = layer_name[len(prefix) :]
-            if stripped in RSLEARN_TO_OLMOEARTH:
-                return RSLEARN_TO_OLMOEARTH[stripped]
+    resolved = resolve_rslearn_layer_name(layer_name)
+    if resolved is not None:
+        return RSLEARN_TO_OLMOEARTH[resolved]
 
     raise KeyError(f"Unknown rslearn layer name: {layer_name!r}")
 

--- a/olmoearth_pretrain/internal/all_evals.py
+++ b/olmoearth_pretrain/internal/all_evals.py
@@ -419,10 +419,6 @@ EVAL_TASKS = {
         epochs=50,
         eval_mode=EvalMode.LINEAR_PROBE,
     ),
-    # MapBiomas 3k segmentation (registry datasets). Mirrors the rslearn frozen-
-    # backbone configs in rslearn_projects/data/helios/mapbiomas/*. primary_metric
-    # is MACRO_F1 so the headline eval/{name} is directly comparable to rslearn's
-    # val_segment/F1; miou and the other metrics are still logged under eval_other.
     "mapbiomas_3k_dense": DownstreamTaskConfig(
         dataset="mapbiomas_3k_dense",
         embedding_batch_size=32,
@@ -440,23 +436,23 @@ EVAL_TASKS = {
         eval_mode=EvalMode.LINEAR_PROBE,
         primary_metric=EvalMetric.MACRO_F1,
     ),
-    "mapbiomas_3k_sparse": DownstreamTaskConfig(
-        dataset="mapbiomas_3k_sparse",
-        embedding_batch_size=32,
-        probe_batch_size=8,
-        num_workers=8,
-        pooling_type=PoolingType.MEAN,
-        norm_stats_from_pretrained=True,
-        norm_method=NormMethod.NORM_NO_CLIP_2_STD,
-        probe_lr=0.0001,
-        eval_interval=Duration.epochs(10),
-        input_modalities=[
-            Modality.SENTINEL2_L2A.name,
-        ],
-        epochs=50,
-        eval_mode=EvalMode.LINEAR_PROBE,
-        primary_metric=EvalMetric.MACRO_F1,
-    ),
+    # "mapbiomas_3k_sparse": DownstreamTaskConfig(
+    #     dataset="mapbiomas_3k_sparse",
+    #     embedding_batch_size=32,
+    #     probe_batch_size=8,
+    #     num_workers=8,
+    #     pooling_type=PoolingType.MEAN,
+    #     norm_stats_from_pretrained=True,
+    #     norm_method=NormMethod.NORM_NO_CLIP_2_STD,
+    #     probe_lr=0.0001,
+    #     eval_interval=Duration.epochs(10),
+    #     input_modalities=[
+    #         Modality.SENTINEL2_L2A.name,
+    #     ],
+    #     epochs=50,
+    #     eval_mode=EvalMode.LINEAR_PROBE,
+    #     primary_metric=EvalMetric.MACRO_F1,
+    # ),
 }
 
 PRETRAIN_SUBSET_H5PY_DIR = "/weka/dfive-default/helios/dataset/osm_sampling/h5py_data_w_missing_timesteps_zstd_3_128_x_4/cdl_gse_landsat_openstreetmap_raster_sentinel1_sentinel2_l2a_srtm_worldcereal_worldcover_worldpop_wri_canopy_height_map/1138828"

--- a/olmoearth_pretrain/internal/all_evals.py
+++ b/olmoearth_pretrain/internal/all_evals.py
@@ -419,6 +419,44 @@ EVAL_TASKS = {
         epochs=50,
         eval_mode=EvalMode.LINEAR_PROBE,
     ),
+    # MapBiomas 3k segmentation (registry datasets). Mirrors the rslearn frozen-
+    # backbone configs in rslearn_projects/data/helios/mapbiomas/*. primary_metric
+    # is MACRO_F1 so the headline eval/{name} is directly comparable to rslearn's
+    # val_segment/F1; miou and the other metrics are still logged under eval_other.
+    "mapbiomas_3k_dense": DownstreamTaskConfig(
+        dataset="mapbiomas_3k_dense",
+        embedding_batch_size=32,
+        probe_batch_size=8,
+        num_workers=8,
+        pooling_type=PoolingType.MEAN,
+        norm_stats_from_pretrained=True,
+        norm_method=NormMethod.NORM_NO_CLIP_2_STD,
+        probe_lr=0.001,
+        eval_interval=Duration.epochs(10),
+        input_modalities=[
+            Modality.SENTINEL2_L2A.name,
+        ],
+        epochs=50,
+        eval_mode=EvalMode.LINEAR_PROBE,
+        primary_metric=EvalMetric.MACRO_F1,
+    ),
+    "mapbiomas_3k_sparse": DownstreamTaskConfig(
+        dataset="mapbiomas_3k_sparse",
+        embedding_batch_size=32,
+        probe_batch_size=8,
+        num_workers=8,
+        pooling_type=PoolingType.MEAN,
+        norm_stats_from_pretrained=True,
+        norm_method=NormMethod.NORM_NO_CLIP_2_STD,
+        probe_lr=0.0001,
+        eval_interval=Duration.epochs(10),
+        input_modalities=[
+            Modality.SENTINEL2_L2A.name,
+        ],
+        epochs=50,
+        eval_mode=EvalMode.LINEAR_PROBE,
+        primary_metric=EvalMetric.MACRO_F1,
+    ),
 }
 
 PRETRAIN_SUBSET_H5PY_DIR = "/weka/dfive-default/helios/dataset/osm_sampling/h5py_data_w_missing_timesteps_zstd_3_128_x_4/cdl_gse_landsat_openstreetmap_raster_sentinel1_sentinel2_l2a_srtm_worldcereal_worldcover_worldpop_wri_canopy_height_map/1138828"


### PR DESCRIPTION
**Executive Summary:** Introduces the MapBiomas 3k land-use/land-cover segmentation benchmark (28-class dense variant) as a new downstream eval task using Sentinel-2 L2A, while consolidating duplicated layer-name resolution logic and simplifying the dataset ingest pipeline.

**Key Changes:**

New MapBiomas eval tasks — Adds mapbiomas_3k_dense (28-class segmentation, Sentinel-2 L2A, linear probe with Macro-F1 metric) to the eval registry and all_evals.py. A sparse variant is defined but commented out pending validation that dense is the primary eval.

Centralized layer-name resolution — Extracts resolve_rslearn_layer_name() into evals/constants.py with enhanced matching (direct, prefix-stripped pre_/post_, and progressive suffix-stripping), replacing three duplicated implementations across rslearn_dataset.py, band_stats.py, and schema.py.

1.1 Checkpoint sweep:
<img width="1766" height="645" alt="image" src="https://github.com/user-attachments/assets/5526fede-6dd3-4498-8a5b-53821e4ed942" />
