### PR TITLE
similar but different eval

### DIFF
--- a/olmoearth_pretrain/evals/datasets/__init__.py
+++ b/olmoearth_pretrain/evals/datasets/__init__.py
@@ -18,6 +18,7 @@ from .normalize import NormMethod
 from .pastis_dataset import PASTISRDataset
 from .pretrain_subset import PretrainSubsetDataset
 from .rslearn_dataset import from_registry_entry
+from .sbd_dataset import SBDDataset
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +149,14 @@ def get_eval_dataset(
     elif eval_dataset == "breizhcrops":
         return BreizhCropsDataset(
             path_to_splits=paths.BREIZHCROPS_DIR,
+            split=split,
+            label_fraction=label_fraction,
+            norm_stats_from_pretrained=norm_stats_from_pretrained,
+            norm_method=norm_method,
+        )
+    elif eval_dataset == "similar_but_different":
+        return SBDDataset(
+            path_to_splits=paths.SBD_DIR,
             split=split,
             label_fraction=label_fraction,
             norm_stats_from_pretrained=norm_stats_from_pretrained,

--- a/olmoearth_pretrain/evals/datasets/configs.py
+++ b/olmoearth_pretrain/evals/datasets/configs.py
@@ -367,6 +367,17 @@ DATASET_TO_CONFIG = {
         ],
         timeseries=True,
     ),
+    # Similar But Different: 10-class ESA WorldCover land-cover classification on
+    # single-timestamp Sentinel-2 L2A 32x32 patches, built so RGB is uninformative.
+    # 12 L2A bands, no cirrus -> no imputes (uses the L2A band path).
+    "similar_but_different": EvalDatasetConfig(
+        task_type=TaskType.CLASSIFICATION,
+        imputes=[],
+        num_classes=10,
+        is_multilabel=False,
+        supported_modalities=[Modality.SENTINEL2_L2A.name],
+        source_imagery=[SourceImagery.SENTINEL2],
+    ),
 }
 
 # "gb2-" prefix denotes geobench v2 datasets

--- a/olmoearth_pretrain/evals/datasets/paths.py
+++ b/olmoearth_pretrain/evals/datasets/paths.py
@@ -15,6 +15,7 @@ _DEFAULTS = {
     "PASTIS_DIR_ORIG": "/weka/dfive-default/presto_eval_sets/pastis_r_origsize",
     "PASTIS_DIR_PARTITION": "/weka/dfive-default/presto_eval_sets/pastis",
     "FIFTY_CITIES_DIR": "/weka/dfive-default/presto_eval_sets/fifty_cities",
+    "SBD_DIR": "/weka/dfive-default/presto_eval_sets/similar_but_different",
 }
 
 GEOBENCH_DIR = UPath(os.getenv("GEOBENCH_DIR", _DEFAULTS["GEOBENCH_DIR"]))
@@ -28,3 +29,4 @@ PASTIS_DIR_PARTITION = UPath(
     os.getenv("PASTIS_DIR_PARTITION", _DEFAULTS["PASTIS_DIR_PARTITION"])
 )
 FIFTY_CITIES_DIR = UPath(os.getenv("FIFTY_CITIES_DIR", _DEFAULTS["FIFTY_CITIES_DIR"]))
+SBD_DIR = UPath(os.getenv("SBD_DIR", _DEFAULTS["SBD_DIR"]))

--- a/olmoearth_pretrain/evals/datasets/sbd_dataset.py
+++ b/olmoearth_pretrain/evals/datasets/sbd_dataset.py
@@ -1,0 +1,139 @@
+"""Similar But Different (SBD) dataset class for evals.
+
+Ten-class ESA WorldCover classification on 30,927 Sentinel-2 L2A 32x32 patches
+(12 bands), built so the visible bands are uninformative by construction -- a probe
+for whether a model uses the non-visible bands. Prepared into per-split tensors by
+``sbd_processor``. See ``sbd_processor`` for the source/layout, and
+https://huggingface.co/datasets/calebrob6/similar-but-different for the dataset.
+
+Mirrors the FiftyCities/MADOS L2A path: stored patches are raw uint16 surface
+reflectance in ``EVAL_S2_L2A_BAND_NAMES`` order; they are normalized (either with the
+pretrained model's stats or this dataset's committed stats) and reindexed to the model
+band order via ``EVAL_TO_OLMOEARTH_S2_L2A_BANDS`` before being wrapped in an
+``OlmoEarthSample``.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+import torch
+from einops import repeat
+from torch.utils.data import Dataset
+
+from olmoearth_pretrain.data.constants import Modality
+from olmoearth_pretrain.data.dataset import OlmoEarthSample
+from olmoearth_pretrain.train.masking import MaskedOlmoEarthSample
+
+from .constants import EVAL_S2_L2A_BAND_NAMES, EVAL_TO_OLMOEARTH_S2_L2A_BANDS
+from .normalize import NormMethod, normalize_bands
+
+logger = logging.getLogger(__name__)
+
+
+class SBDDataset(Dataset):
+    """Similar But Different classification dataset (Sentinel-2 L2A, 10 classes)."""
+
+    # Single fixed timestamp: SBD ships one composite date per patch (no true date),
+    # matching the single-timestamp convention of the other patch eval sets.
+    default_day_month_year = [1, 6, 2021]
+
+    def __init__(
+        self,
+        path_to_splits: Path,
+        split: str,
+        label_fraction: float = 1.0,
+        norm_stats_from_pretrained: bool = True,
+        norm_method: str = NormMethod.NORM_NO_CLIP_2_STD,
+    ):
+        """Init the SBD dataset.
+
+        Args:
+            path_to_splits: dir written by sbd_processor (SBD_{split}.pt + norm_stats.json).
+            split: one of train / val / valid / test.
+            label_fraction: fraction of train patches to keep (stratified by class).
+            norm_stats_from_pretrained: if True, normalize with the pretrained model's
+                stats (Normalizer COMPUTED); else use this dataset's committed stats.
+            norm_method: normalization method used only when not using pretrained stats.
+        """
+        assert split in ["train", "val", "valid", "test"]
+        if split == "valid":
+            split = "val"
+        self.split = split
+        self.norm_method = norm_method
+        self.norm_stats_from_pretrained = norm_stats_from_pretrained
+
+        path_to_splits = Path(path_to_splits)
+        obj = torch.load(path_to_splits / f"SBD_{split}.pt")
+        self.images = obj["images"]  # (N, 32, 32, 12) uint16
+        self.labels = obj["labels"].long()  # (N,)
+        self.patch_ids = obj["patch_ids"]
+
+        if norm_stats_from_pretrained:
+            from olmoearth_pretrain.data.normalize import Normalizer, Strategy
+
+            self.normalizer_computed = Normalizer(Strategy.COMPUTED)
+        else:
+            stats = json.loads((path_to_splits / "norm_stats.json").read_text())
+            self.means, self.stds, self.mins, self.maxs = self._stats_arrays(stats)
+
+        if not 0 < label_fraction <= 1:
+            raise ValueError("label_fraction must be in (0, 1].")
+        if label_fraction < 1.0 and split == "train":
+            self._subsample_train(label_fraction)
+
+    @staticmethod
+    def _stats_arrays(
+        stats: dict[str, dict[str, float]],
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        means, stds, mins, maxs = [], [], [], []
+        for band in EVAL_S2_L2A_BAND_NAMES:
+            s = stats[band]
+            means.append(s["mean"])
+            stds.append(s["std"])
+            mins.append(s["min"])
+            maxs.append(s["max"])
+        return np.array(means), np.array(stds), np.array(mins), np.array(maxs)
+
+    def _subsample_train(self, label_fraction: float) -> None:
+        """Keep a class-stratified fraction of the train patches (deterministic)."""
+        rng = np.random.default_rng(42)
+        keep = []
+        labels = self.labels.numpy()
+        for cls in np.unique(labels):
+            idx = np.where(labels == cls)[0]
+            n = max(1, int(round(len(idx) * label_fraction)))
+            keep.append(rng.choice(idx, size=n, replace=False))
+        keep_idx = np.sort(np.concatenate(keep))
+        # torch can't advanced-index a uint16 CPU tensor, so select via numpy.
+        self.images = torch.from_numpy(self.images.numpy()[keep_idx])
+        self.labels = self.labels[torch.from_numpy(keep_idx)]
+        self.patch_ids = [self.patch_ids[i] for i in keep_idx]
+
+    def __len__(self) -> int:
+        """Number of patches in this split."""
+        return self.images.shape[0]
+
+    def __getitem__(self, idx: int) -> tuple[MaskedOlmoEarthSample, torch.Tensor]:
+        """Return one patch as a (masked sample, scalar label) pair."""
+        image = self.images[idx].numpy().astype(np.float32)  # (32, 32, 12), raw SR
+
+        if not self.norm_stats_from_pretrained:
+            image = normalize_bands(
+                image, self.means, self.stds, self.mins, self.maxs, self.norm_method
+            )
+        # (H, W, C) -> (H, W, T=1, C), then reindex to the model's S2 L2A band order.
+        image = repeat(image, "h w c -> h w t c", t=1)[
+            :, :, :, EVAL_TO_OLMOEARTH_S2_L2A_BANDS
+        ]
+        if self.norm_stats_from_pretrained:
+            image = self.normalizer_computed.normalize(Modality.SENTINEL2_L2A, image)
+
+        timestamp = repeat(torch.tensor(self.default_day_month_year), "d -> t d", t=1)
+        masked_sample = MaskedOlmoEarthSample.from_olmoearthsample(
+            OlmoEarthSample(
+                sentinel2_l2a=torch.tensor(image).float(), timestamps=timestamp.long()
+            )
+        )
+        return masked_sample, self.labels[idx]

--- a/olmoearth_pretrain/evals/datasets/sbd_processor.py
+++ b/olmoearth_pretrain/evals/datasets/sbd_processor.py
@@ -1,0 +1,154 @@
+"""Prepare the "Similar But Different" (SBD) eval dataset into per-split tensors.
+
+Source: HuggingFace dataset ``calebrob6/similar-but-different`` -- 30,927 Sentinel-2
+L2A 32x32 patches (12 bands, GeoTIFF bytes in per-class parquet shards) across ten
+ESA WorldCover classes, with a fixed scene-disjoint 80/10/10 split in ``splits.json``.
+See https://huggingface.co/datasets/calebrob6/similar-but-different.
+
+This mirrors ``fifty_cities_processor``/``process_mados``: it downloads the shards,
+decodes each patch's embedded GeoTIFF, and writes, per split, an ``SBD_{split}.pt``
+holding raw uint16 surface-reflectance images ``(N, 32, 32, 12)``, scalar class labels
+``(N,)``, and the patch ids. It also writes ``norm_stats.json`` (train-split per-band
+mean/std + robust min/max, on the raw-SR scale the framework expects) and copies the
+pair/cluster eval artifacts.
+
+Band order in the stored images is the source order, which equals
+``EVAL_S2_L2A_BAND_NAMES``: B01, B02, B03, B04, B05, B06, B07, B08, B8A, B09, B11, B12.
+
+Usage:
+    python -m olmoearth_pretrain.evals.datasets.sbd_processor \
+        --out_dir /weka/dfive-default/presto_eval_sets/similar_but_different
+"""
+
+import argparse
+import io
+import json
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import rasterio
+import tqdm
+from huggingface_hub import snapshot_download
+
+REPO_ID = "calebrob6/similar-but-different"
+# Pinned dataset revision (commit SHA) for reproducibility. Passed as a literal to
+# snapshot_download below so the download is version-locked (and static analysis can
+# verify the pin). Bump this when intentionally moving to a newer dataset revision.
+REVISION = "6104443755c3fab82ab148f7053f9f05a75677b1"
+# The 12 L2A bands, in the order they appear in each patch GeoTIFF (== EVAL_S2_L2A_BAND_NAMES).
+BAND_NAMES = [
+    "01 - Coastal aerosol",
+    "02 - Blue",
+    "03 - Green",
+    "04 - Red",
+    "05 - Vegetation Red Edge",
+    "06 - Vegetation Red Edge",
+    "07 - Vegetation Red Edge",
+    "08 - NIR",
+    "08A - Vegetation Red Edge",
+    "09 - Water vapour",
+    "11 - SWIR",
+    "12 - SWIR",
+]
+SPLITS = ["train", "val", "test"]
+
+
+def _decode_tif(tif_bytes: bytes) -> np.ndarray:
+    """Decode a patch GeoTIFF -> (32, 32, 12) uint16 (H, W, C)."""
+    with rasterio.open(io.BytesIO(tif_bytes)) as src:
+        arr = src.read()  # (12, 32, 32)
+    return np.transpose(arr, (1, 2, 0))  # (32, 32, 12)
+
+
+def main() -> None:
+    """Download SBD, decode shards, and write per-split tensors + norm stats."""
+    import torch
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--out_dir",
+        default="/weka/dfive-default/presto_eval_sets/similar_but_different",
+    )
+    ap.add_argument("--hf_cache", default=None, help="optional HF download cache dir")
+    args = ap.parse_args()
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"downloading {REPO_ID}@{REVISION[:8]} ...")
+    local = snapshot_download(
+        repo_id=REPO_ID,
+        repo_type="dataset",
+        revision="6104443755c3fab82ab148f7053f9f05a75677b1",  # == REVISION; literal for static pin check
+        cache_dir=args.hf_cache,
+    )
+    local = Path(local)
+
+    splits = json.loads((local / "splits.json").read_text())
+    class_to_idx = splits["class_to_idx"]
+    # patch_id -> split
+    pid_to_split = {}
+    for split in SPLITS:
+        for _cls, pids in splits[split].items():
+            for pid in pids:
+                pid_to_split[pid] = split
+
+    buffers: dict[str, dict[str, list]] = {
+        s: {"images": [], "labels": [], "patch_ids": []} for s in SPLITS
+    }
+
+    shard_files = sorted((local / "shards").glob("*.parquet"))
+    print(f"decoding {len(shard_files)} shards ...")
+    for shard in shard_files:
+        df = pd.read_parquet(shard)
+        for _, row in tqdm.tqdm(df.iterrows(), total=len(df), desc=shard.stem):
+            pid = row["patch_id"]
+            patch_split = pid_to_split.get(pid)
+            if patch_split is None:
+                continue  # patch not in any split (shouldn't happen)
+            img = _decode_tif(row["tif"])  # (32, 32, 12) uint16
+            buffers[patch_split]["images"].append(img)
+            buffers[patch_split]["labels"].append(class_to_idx[row["wc_mode_label"]])
+            buffers[patch_split]["patch_ids"].append(pid)
+
+    for split in SPLITS:
+        imgs = np.stack(buffers[split]["images"]).astype(np.uint16)  # (N,32,32,12)
+        labels = np.array(buffers[split]["labels"], dtype=np.int64)
+        torch.save(
+            {
+                "images": torch.from_numpy(imgs),
+                "labels": torch.from_numpy(labels),
+                "patch_ids": buffers[split]["patch_ids"],
+            },
+            out_dir / f"SBD_{split}.pt",
+        )
+        print(f"  {split}: {imgs.shape[0]} patches -> SBD_{split}.pt")
+
+    # Train-split per-band norm stats on the raw-SR scale (mean/std + robust 2/98 pct).
+    train_imgs = np.stack(buffers["train"]["images"]).astype(np.float64)
+    flat = train_imgs.reshape(-1, len(BAND_NAMES))  # (N*32*32, 12)
+    norm_stats = {}
+    for i, band in enumerate(BAND_NAMES):
+        col = flat[:, i]
+        norm_stats[band] = {
+            "mean": float(col.mean()),
+            "std": float(col.std()),
+            "min": float(np.percentile(col, 2)),
+            "max": float(np.percentile(col, 98)),
+        }
+    (out_dir / "norm_stats.json").write_text(json.dumps(norm_stats, indent=2))
+    (out_dir / "class_to_idx.json").write_text(json.dumps(class_to_idx, indent=2))
+
+    # Copy the pair/cluster eval artifacts for future similar-but-different metrics.
+    eval_dst = out_dir / "eval"
+    eval_dst.mkdir(exist_ok=True)
+    for name in ["test_pairs.parquet", "test_hard_clusters.parquet"]:
+        src = local / "eval" / name
+        if src.exists():
+            shutil.copy(src, eval_dst / name)
+    print(f"wrote norm_stats.json, class_to_idx.json, eval/ to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/olmoearth_pretrain/internal/all_evals.py
+++ b/olmoearth_pretrain/internal/all_evals.py
@@ -76,6 +76,25 @@ EVAL_TASKS = {
         eval_mode=EvalMode.KNN,
         primary_metric=EvalMetric.ACCURACY,
     ),
+    # Similar But Different: 10-class ESA WorldCover land-cover classification on
+    # single-timestamp Sentinel-2 L2A 32x32 patches, built so RGB is uninformative
+    # (a probe for spectral-band reliance). Linear probe on frozen embeddings -- the
+    # setting the dataset's headline foundation-model numbers report.
+    "similar_but_different": DownstreamTaskConfig(
+        dataset="similar_but_different",
+        embedding_batch_size=128,
+        probe_batch_size=128,
+        num_workers=8,
+        pooling_type=PoolingType.MEAN,
+        norm_stats_from_pretrained=True,
+        norm_method=NormMethod.NORM_NO_CLIP_2_STD,
+        probe_lr=0.01,
+        eval_interval=Duration.epochs(5),
+        input_modalities=[Modality.SENTINEL2_L2A.name],
+        epochs=50,
+        eval_mode=EvalMode.LINEAR_PROBE,
+        primary_metric=EvalMetric.ACCURACY,
+    ),
     "m_forestnet": DownstreamTaskConfig(
         dataset="m-forestnet",
         embedding_batch_size=64,


### PR DESCRIPTION
30k Sentinel2 patches across 10 worldcover classes, selected so that every patch has an "RGB doppelganger" from a different class. Seems like a promising way to evaluate if our models are actually utilizing multispectral information. I'm not adding this to in-loop evals, but it could be something we evaluate models on if we want to assess this specifically. 

Linear probe experiment with olmoearth v1.2 achieved 0.862, compared to the reported 0.867