### PR TITLE
Fix compile bug involving rope

### DIFF
--- a/olmoearth_pretrain/nn/encodings.py
+++ b/olmoearth_pretrain/nn/encodings.py
@@ -39,12 +39,16 @@ class PositionEncoding(StrEnum):
     @classmethod
     def is_2d_rope(cls, value: str) -> bool:
         """Return whether ``value`` selects a 2D RoPE encoding."""
-        return value in {cls.AXIAL_2D_ROPE, cls.MIXED_2D_ROPE}
+        # Compare against plain strings, not enum members: Dynamo (at least through
+        # torch 2.7.1) mis-evaluates `str in {StrEnum members}` as False, which would
+        # silently drop RoPE from compiled attention blocks (see Attention.forward).
+        return value in (cls.AXIAL_2D_ROPE.value, cls.MIXED_2D_ROPE.value)
 
     @classmethod
     def is_3d_rope(cls, value: str) -> bool:
         """Return whether ``value`` selects a 3D RoPE encoding."""
-        return value in {cls.AXIAL_3D_ROPE, cls.MIXED_3D_ROPE}
+        # Plain-string comparison for torch.compile correctness; see is_2d_rope.
+        return value in (cls.AXIAL_3D_ROPE.value, cls.MIXED_3D_ROPE.value)
 
     @classmethod
     def is_rope(cls, value: str) -> bool:

--- a/tests/unit/nn/test_attention.py
+++ b/tests/unit/nn/test_attention.py
@@ -1,0 +1,61 @@
+"""Unit tests for attention components."""
+
+import pytest
+import torch
+
+from olmoearth_pretrain.nn.attention import Attention
+
+
+def _grid_positions(b: int, side: int) -> torch.Tensor:
+    rows = torch.arange(side).repeat_interleave(side)
+    cols = torch.arange(side).repeat(side)
+    grid = torch.stack([rows, cols], dim=-1).float()  # (side*side, 2)
+    return grid.unsqueeze(0).expand(b, -1, -1).contiguous()
+
+
+@pytest.mark.parametrize(
+    "position_encoding,num_coords",
+    [("rope", 2), ("rope_mixed", 2), ("rope_3d", 3), ("rope_3d_mixed", 3)],
+)
+def test_compiled_attention_applies_rope(
+    position_encoding: str, num_coords: int
+) -> None:
+    """Compiled attention output must match eager for every RoPE mode.
+
+    Regression test: Dynamo mis-evaluated the ``PositionEncoding.is_rope`` guard in
+    Attention.forward when ``self.position_encoding`` is a plain config string
+    (str-vs-StrEnum-set membership), so compiled blocks silently skipped RoPE.
+    The position_encoding is passed as a plain str, like when built from a config.
+    """
+    torch._dynamo.reset()
+    # head_dim=16 satisfies %4 (2D/mixed modes) and the axial 3D dim split.
+    b, h, side, d = 2, 2, 4, 16
+    n = side * side
+    attn = Attention(
+        dim=h * d,
+        num_heads=h,
+        attn_drop=0.0,
+        position_encoding=position_encoding,
+    ).eval()
+
+    torch.manual_seed(0)
+    x = torch.randn(b, n, h * d)
+    positions = _grid_positions(b, side)
+    if num_coords == 3:
+        # Prepend a nonzero temporal coordinate: (t, row, col).
+        t = torch.arange(n).remainder(3).float()
+        t = t.unsqueeze(0).expand(b, -1).unsqueeze(-1)
+        positions = torch.cat([t, positions], dim=-1)
+
+    with torch.no_grad():
+        eager = attn(x, rope_positions=positions)
+        compiled = torch.compile(attn, backend="eager", fullgraph=True)(
+            x, rope_positions=positions
+        )
+        # Sanity check that RoPE actually affects the output, so a compiled graph
+        # that dropped RoPE could not pass this test vacuously.
+        no_rope = Attention(dim=h * d, num_heads=h, attn_drop=0.0).eval()
+        no_rope.load_state_dict(attn.state_dict(), strict=False)
+        assert not torch.allclose(no_rope(x), eager)
+
+    torch.testing.assert_close(compiled, eager)

--- a/tests/unit/nn/test_encodings.py
+++ b/tests/unit/nn/test_encodings.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from olmoearth_pretrain.nn.encodings import (
+    PositionEncoding,
     apply_1d_rope,
     apply_2d_axial_rope,
     apply_2d_mixed_rope,
@@ -562,3 +563,27 @@ def test_timestamps_to_days_rejects_bad_last_dim() -> None:
     """Non-3 last dim should raise."""
     with pytest.raises(ValueError):
         timestamps_to_days(torch.zeros(2, 2, dtype=torch.long))
+
+
+@pytest.mark.parametrize(
+    "value", [encoding.value for encoding in PositionEncoding] + list(PositionEncoding)
+)
+def test_is_rope_traces_correctly_under_torch_compile(value: str) -> None:
+    """torch.compile must take the same is_rope branch as eager Python.
+
+    Regression test: Dynamo (at least through torch 2.7.1) mis-evaluates
+    ``"rope_3d_mixed" in {StrEnum members}`` as False, which silently dropped all
+    RoPE ops from compiled attention blocks. is_rope/is_2d_rope/is_3d_rope must
+    therefore compare against plain strings.
+    """
+    torch._dynamo.reset()
+
+    def f(x: torch.Tensor, s: str) -> torch.Tensor:
+        if PositionEncoding.is_rope(s):
+            return x + 1
+        return x - 1
+
+    x = torch.zeros(1)
+    eager = f(x, value)
+    compiled = torch.compile(f, backend="eager", fullgraph=True)(x, value)
+    torch.testing.assert_close(compiled, eager)


### PR DESCRIPTION
Previously the compiled model would have incorrect outputs for models where RoPE is enabled. RoPE was skipped because of some str / enum divergence between normal python code and dynamo