### PR TITLE
Graceful shutdowns

### DIFF
--- a/olmoearth_pretrain/data/dataloader.py
+++ b/olmoearth_pretrain/data/dataloader.py
@@ -56,7 +56,6 @@ def _worker_ignore_sigterm(worker_id: int) -> None:
     from running (stuck ranks then get SIGKILLed, which can leave GPUs in a bad
     state). Workers must instead stay alive until the parent shuts them down.
     """
-    del worker_id
     signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
 

--- a/olmoearth_pretrain/data/dataloader.py
+++ b/olmoearth_pretrain/data/dataloader.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import math
 import multiprocessing as mp
+import signal
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -43,6 +44,20 @@ from olmoearth_pretrain.nn.tokenization import TokenizationConfig
 from olmoearth_pretrain.train.masking import MaskingConfig, MaskingStrategy
 
 logger = logging.getLogger(__name__)
+
+
+def _worker_ignore_sigterm(worker_id: int) -> None:
+    """Make dataloader workers ignore SIGTERM.
+
+    On preemption, torchrun delivers SIGTERM to each rank's whole process group,
+    including dataloader workers. If the workers die, PyTorch's SIGCHLD watchdog
+    raises a RuntimeError in the middle of the training step, which crashes ranks
+    asymmetrically mid-NCCL-collective and prevents olmo-core's graceful cancel
+    from running (stuck ranks then get SIGKILLed, which can leave GPUs in a bad
+    state). Workers must instead stay alive until the parent shuts them down.
+    """
+    del worker_id
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
 
 class OlmoEarthDataLoader(DataLoaderBase):
@@ -272,6 +287,7 @@ class OlmoEarthDataLoader(DataLoaderBase):
             multiprocessing_context=(
                 self.multiprocessing_context if self.num_workers > 0 else None
             ),
+            worker_init_fn=_worker_ignore_sigterm if self.num_workers > 0 else None,
             timeout=0,
         )
 

--- a/olmoearth_pretrain/train/callbacks/evaluator_callback.py
+++ b/olmoearth_pretrain/train/callbacks/evaluator_callback.py
@@ -21,6 +21,7 @@ from torch.utils.data import DataLoader, IterableDataset
 from upath import UPath
 
 from olmoearth_pretrain.data.constants import Modality
+from olmoearth_pretrain.data.dataloader import _worker_ignore_sigterm
 from olmoearth_pretrain.evals.datasets import get_eval_dataset
 from olmoearth_pretrain.evals.datasets.configs import (
     EvalDatasetConfig,
@@ -54,6 +55,7 @@ logger = logging.getLogger(__name__)
 
 def _seed_worker(worker_id: int, base_seed: int) -> None:
     """Seed DataLoader worker RNGs deterministically."""
+    _worker_ignore_sigterm(worker_id)
     worker_seed = base_seed + worker_id
     random.seed(worker_seed)
     np.random.seed(worker_seed)
@@ -310,7 +312,7 @@ class DownstreamEvaluator:
         )
 
         generator = None
-        worker_init_fn = None
+        worker_init_fn: Any = _worker_ignore_sigterm
         if seed is not None:
             split_offsets = {"train": 0, "valid": 1, "test": 2}
             split_seed = seed + split_offsets.get(split, 0)


### PR DESCRIPTION
Previously, the sigterm from preemptions was getting fed through to the dataloader workers. These didn't shut down gracefully (crashed the training ranks midstep), occasionally requiring a GPU reboot.

This change means that the sigterm is ignored by the dataloader workers, allowing olmo-core's graceful shutdown to happen. 